### PR TITLE
 Feature | #13 | @lcomment | FCM 설정 및 전송 비즈니스 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 
 ### generated ###
 src/main/generated/
+
+### firebase ###
+/lovebird-external/fcm/src/main/resources/firebase/lovebird-firebase-admin-sdk.json

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@ springDependencyManagementVersion=1.1.4
 ### External Dependency versions ###
 sentryVersion=6.33.0
 querydslVersion=5.0.0
+coroutinesVersion=1.8.0-RC

--- a/lovebird-api/build.gradle.kts
+++ b/lovebird-api/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 	implementation(project(":lovebird-domain"))
 	implementation(project(":lovebird-security"))
 	implementation(project(":lovebird-external:s3"))
+	implementation(project(":lovebird-external:fcm"))
 	implementation(project(":lovebird-infra:logging"))
 	implementation(project(":lovebird-infra:monitoring"))
 

--- a/lovebird-api/src/main/resources/application.yml
+++ b/lovebird-api/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
             - security-${spring.profiles.default}.yml
             - client-${spring.profiles.default}.yml
             - s3-${spring.profiles.default}.yml
+            - fcm.yml
             - logging-${spring.profiles.default}.yml
             - monitoring.yml
 

--- a/lovebird-external/fcm/build.gradle.kts
+++ b/lovebird-external/fcm/build.gradle.kts
@@ -1,0 +1,6 @@
+description = "fcm module"
+
+dependencies {
+	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("com.google.firebase:firebase-admin:9.2.0")
+}

--- a/lovebird-external/fcm/build.gradle.kts
+++ b/lovebird-external/fcm/build.gradle.kts
@@ -3,4 +3,15 @@ description = "fcm module"
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.google.firebase:firebase-admin:9.2.0")
+
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${property("coroutinesVersion")}")
+	runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:${property("coroutinesVersion")}")
+	runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:${property("coroutinesVersion")}")
+
+	implementation("org.springframework.boot:spring-boot-starter-log4j2")
+}
+
+configurations.forEach {
+	it.exclude(group = "org.springframework.boot", module = "spring-boot-starter-logging")
+	it.exclude(group = "org.apache.logging.log4j", module = "log4j-to-slf4j")
 }

--- a/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/config/FCMConfig.kt
+++ b/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/config/FCMConfig.kt
@@ -1,0 +1,31 @@
+package com.lovebird.fcm.config
+
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.firebase.FirebaseApp
+import com.google.firebase.FirebaseOptions
+import jakarta.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.io.ClassPathResource
+
+
+@Configuration
+class FCMConfig(
+	@Value("\${firebase.certification}")
+	private val adminSdk: String,
+	@Value("\${firebase.scope}")
+	private val scope: String
+) {
+
+	@PostConstruct
+	fun firebaseApp() {
+		val account = ClassPathResource(adminSdk)
+		FirebaseApp.initializeApp(getOptions(account))
+	}
+
+	private fun getOptions(config: ClassPathResource): FirebaseOptions {
+		return FirebaseOptions.builder()
+			.setCredentials(GoogleCredentials.fromStream(config.getInputStream()).createScoped(setOf(scope)))
+			.build()
+	}
+}

--- a/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/config/FirebaseConfig.kt
+++ b/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/config/FirebaseConfig.kt
@@ -10,7 +10,7 @@ import org.springframework.core.io.ClassPathResource
 
 
 @Configuration
-class FCMConfig(
+class FirebaseConfig(
 	@Value("\${firebase.certification}")
 	private val adminSdk: String,
 	@Value("\${firebase.scope}")

--- a/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/config/FirebaseConfig.kt
+++ b/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/config/FirebaseConfig.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.ClassPathResource
 
-
 @Configuration
 class FirebaseConfig(
 	@Value("\${firebase.certification}")

--- a/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/dto/param/FcmDataParam.kt
+++ b/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/dto/param/FcmDataParam.kt
@@ -1,0 +1,6 @@
+package com.lovebird.fcm.dto.param
+
+data class FcmDataParam(
+	val key: String,
+	val value: String
+)

--- a/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/dto/param/FcmNotificationParam.kt
+++ b/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/dto/param/FcmNotificationParam.kt
@@ -1,8 +1,12 @@
 package com.lovebird.fcm.dto.param
 
 data class FcmNotificationParam(
-	val deviceToken: String,
+	val deviceTokens: List<String>,
 	val title: String,
 	val body: String,
 	val data: List<FcmDataParam>
-)
+) {
+	fun toDataMap(): Map<String, String> {
+		return data.associate { it.key to it.value }
+	}
+}

--- a/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/dto/param/FcmNotificationParam.kt
+++ b/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/dto/param/FcmNotificationParam.kt
@@ -1,0 +1,8 @@
+package com.lovebird.fcm.dto.param
+
+data class FcmNotificationParam(
+	val deviceToken: String,
+	val title: String,
+	val body: String,
+	val data: List<FcmDataParam>
+)

--- a/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/service/FcmService.kt
+++ b/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/service/FcmService.kt
@@ -30,15 +30,15 @@ class FcmService(
 
 			loggingFailToken(response, param.deviceTokens)
 		} catch (e: FirebaseMessagingException) {
-			logger.error("cannot send to memberList push message. error info : {${e.message}}");
+			logger.error("cannot send to memberList push message. error info : {${e.message}}")
 		}
 	}
 
 	private fun loggingFailToken(response: BatchResponse, tokenList: List<String>) {
 		when {
 			response.failureCount > 0 -> {
-				val responses: List<SendResponse> = response.responses;
-				val failedTokens = mutableListOf<String>();
+				val responses: List<SendResponse> = response.responses
+				val failedTokens = mutableListOf<String>()
 
 				responses.indices
 					.filterNot { responses[it].isSuccessful }

--- a/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/service/FcmService.kt
+++ b/lovebird-external/fcm/src/main/kotlin/com/lovebird/fcm/service/FcmService.kt
@@ -1,0 +1,73 @@
+package com.lovebird.fcm.service
+
+import com.google.firebase.messaging.BatchResponse
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.FirebaseMessagingException
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.Notification
+import com.google.firebase.messaging.SendResponse
+import com.lovebird.fcm.dto.param.FcmNotificationParam
+import kotlinx.coroutines.runBlocking
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class FcmService(
+	private val logger: Logger = LoggerFactory.getLogger(FcmService::class.java)
+) {
+
+	fun sendNotificationAsync(param: FcmNotificationParam) {
+		runBlocking {
+			sendAllNotification(param)
+		}
+	}
+
+	suspend fun sendAllNotification(param: FcmNotificationParam) {
+		try {
+			val messages = getMessages(param)
+			val response = FirebaseMessaging.getInstance().sendEach(messages)
+
+			loggingFailToken(response, param.deviceTokens)
+		} catch (e: FirebaseMessagingException) {
+			logger.error("cannot send to memberList push message. error info : {${e.message}}");
+		}
+	}
+
+	private fun loggingFailToken(response: BatchResponse, tokenList: List<String>) {
+		when {
+			response.failureCount > 0 -> {
+				val responses: List<SendResponse> = response.responses;
+				val failedTokens = mutableListOf<String>();
+
+				responses.indices
+					.filterNot { responses[it].isSuccessful }
+					.forEach { failedTokens += tokenList[it] }
+				logger.error("List of tokens are not valid FCM token : ${failedTokens.joinToString(", ")}")
+			}
+		}
+	}
+
+	private fun getMessages(param: FcmNotificationParam): List<Message> {
+		val data = param.toDataMap()
+
+		return param.deviceTokens.map {
+			getMessage(it, getNotification(param.title, param.body), data)
+		}
+	}
+
+	private fun getMessage(deviceToken: String, notification: Notification, data: Map<String, String>): Message {
+		return Message.builder()
+			.setToken(deviceToken)
+			.setNotification(notification)
+			.putAllData(data)
+			.build()
+	}
+
+	private fun getNotification(title: String, body: String): Notification {
+		return Notification.builder()
+			.setTitle(title)
+			.setBody(body)
+			.build()
+	}
+}

--- a/lovebird-external/fcm/src/main/resources/fcm.yml
+++ b/lovebird-external/fcm/src/main/resources/fcm.yml
@@ -1,0 +1,3 @@
+firebase:
+  certification: /firebase/lovebird-firebase-admin-sdk.json
+  scope: https://www.googleapis.com/auth/cloud-platform

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ include(
 	"lovebird-common",
 	"lovebird-domain",
 	"lovebird-external:s3",
+	"lovebird-external:fcm",
 	"lovebird-external:web-client",
 	"lovebird-infra:logging",
 	"lovebird-infra:monitoring"


### PR DESCRIPTION
> ### Issue Number

#13

> ### Description

- fcm 설정
- fcm 전송 비즈니스 로직 구현

> ### Core Code

```kotlin
. . .
	fun sendNotificationAsync(param: FcmNotificationParam) {
		runBlocking {
			sendAllNotification(param)
		}
	}

	suspend fun sendAllNotification(param: FcmNotificationParam) {
		try {
			val messages = getMessages(param)
			val response = FirebaseMessaging.getInstance().sendEach(messages)

			loggingFailToken(response, param.deviceTokens)
		} catch (e: FirebaseMessagingException) {
			logger.error("cannot send to memberList push message. error info : {${e.message}}")
		}
	}
. . .
```

> ### etc

아직 FCM을 어디어디에 사용할지 명확하게 정의되지 않아 비즈니스 로직만 구현했습니다. 전체 회의를 통해 명확히 정의되면 notification에 대한 data log 저장하는 table 설계 및 로깅 기능을 추가 구현하겠습니다.