### PR TITLE
Feature | #14 | @lcomment | Diary 관련 엔티티 및 Query 구현

### DIFF
--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/profile/ProfileUpdateRequest.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/profile/ProfileUpdateRequest.kt
@@ -1,7 +1,7 @@
 package com.lovebird.api.dto.request.profile
 
 import com.lovebird.common.enums.Gender
-import com.lovebird.domain.dto.command.ProfileUpdateParam
+import com.lovebird.domain.dto.command.ProfileUpdateRequestParam
 import java.time.LocalDate
 
 data class ProfileUpdateRequest(
@@ -12,8 +12,8 @@ data class ProfileUpdateRequest(
 	val firstDate: LocalDate?,
 	val gender: Gender?
 ) {
-	fun toParam(): ProfileUpdateParam {
-		return ProfileUpdateParam(
+	fun toParam(): ProfileUpdateRequestParam {
+		return ProfileUpdateRequestParam(
 			imageUrl = imageUrl,
 			email = email,
 			nickname = nickname,

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/response/profile/ProfileDetailResponse.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/response/profile/ProfileDetailResponse.kt
@@ -1,7 +1,7 @@
 package com.lovebird.api.dto.response.profile
 
 import com.lovebird.api.dto.request.profile.AnniversaryResponse
-import com.lovebird.domain.dto.query.ProfileDetailParam
+import com.lovebird.domain.dto.query.ProfileDetailResponseParam
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
@@ -20,7 +20,7 @@ data class ProfileDetailResponse(
 ) {
 	companion object {
 		@JvmStatic
-		fun of(param: ProfileDetailParam): ProfileDetailResponse {
+		fun of(param: ProfileDetailResponseParam): ProfileDetailResponse {
 			return ProfileDetailResponse(
 				userId = param.userId,
 				partnerId = param.partnerId,

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/profile/ProfileService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/profile/ProfileService.kt
@@ -2,7 +2,7 @@ package com.lovebird.api.service.profile
 
 import com.lovebird.api.dto.param.profile.ProfileCreateParam
 import com.lovebird.api.dto.response.profile.ProfileDetailResponse
-import com.lovebird.domain.dto.command.ProfileUpdateParam
+import com.lovebird.domain.dto.command.ProfileUpdateRequestParam
 import com.lovebird.domain.entity.Profile
 import com.lovebird.domain.entity.User
 import com.lovebird.domain.repository.reader.ProfileReader
@@ -22,7 +22,7 @@ class ProfileService(
 	}
 
 	@Transactional
-	fun update(user: User, param: ProfileUpdateParam) {
+	fun update(user: User, param: ProfileUpdateRequestParam) {
 		profileWriter.update(findByUser(user), param)
 	}
 

--- a/lovebird-api/src/main/resources/application.yml
+++ b/lovebird-api/src/main/resources/application.yml
@@ -8,6 +8,7 @@ spring:
         location: classpath:/app-banner.dat
     config:
         import:
+            - common.yml
             - db-${spring.profiles.default}.yml
             - security-${spring.profiles.default}.yml
             - client-${spring.profiles.default}.yml

--- a/lovebird-common/src/main/kotlin/com/lovebird/common/utils/AesEncryptor.kt
+++ b/lovebird-common/src/main/kotlin/com/lovebird/common/utils/AesEncryptor.kt
@@ -1,0 +1,44 @@
+package com.lovebird.common.utils
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.util.*
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+@Component
+class AesEncryptor(
+	@Value("\${aes.secret-key}")
+	private val key: String
+) {
+	private val encoder = Base64.getEncoder()
+	private val decoder = Base64.getDecoder()
+
+	fun encryptString(encryptString: String): String {
+		val encryptedString = cipherPkcs5(Cipher.ENCRYPT_MODE).doFinal(encryptString.toByteArray(Charsets.UTF_8))
+
+		return String(encoder.encode(encryptedString))
+	}
+
+	fun decryptString(decryptString: String): String {
+		val byteString = decoder.decode(decryptString.toByteArray(Charsets.UTF_8))
+
+		return String(cipherPkcs5(Cipher.DECRYPT_MODE).doFinal(byteString))
+	}
+
+	private fun cipherPkcs5(opMode: Int): Cipher {
+		val c = Cipher.getInstance("AES/CBC/PKCS5Padding")
+
+		c.init(opMode, generateAesSecretKey(), generateIvVector())
+		return c
+	}
+
+	private fun generateAesSecretKey(): SecretKeySpec {
+		return SecretKeySpec(key.toByteArray(Charsets.UTF_8), "AES")
+	}
+
+	private fun generateIvVector(): IvParameterSpec {
+		return IvParameterSpec(key.substring(0, 16).toByteArray(Charsets.UTF_8))
+	}
+}

--- a/lovebird-common/src/main/resources/common.yml
+++ b/lovebird-common/src/main/resources/common.yml
@@ -1,0 +1,2 @@
+aes:
+  secret-key: ${AES_SECRET_KEY}

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/command/DiaryUpdateRequestParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/command/DiaryUpdateRequestParam.kt
@@ -1,0 +1,10 @@
+package com.lovebird.domain.dto.command
+
+import java.time.LocalDate
+
+data class DiaryUpdateRequestParam(
+	val title: String?,
+	val memoryDate: LocalDate?,
+	val place: String?,
+	val content: String?
+)

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/command/ProfileUpdateRequestParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/command/ProfileUpdateRequestParam.kt
@@ -3,7 +3,7 @@ package com.lovebird.domain.dto.command
 import com.lovebird.common.enums.Gender
 import java.time.LocalDate
 
-data class ProfileUpdateParam(
+data class ProfileUpdateRequestParam(
 	val imageUrl: String?,
 	val email: String?,
 	val nickname: String?,

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/DiaryListRequestParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/DiaryListRequestParam.kt
@@ -1,0 +1,10 @@
+package com.lovebird.domain.dto.query
+
+import java.time.LocalDate
+
+data class DiaryListRequestParam(
+	val userId: Long,
+	val partnerId: Long,
+	val memoryDate: LocalDate,
+	val pageSize: Long
+)

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/DiaryResponseParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/DiaryResponseParam.kt
@@ -1,0 +1,13 @@
+package com.lovebird.domain.dto.query
+
+import java.time.LocalDate
+
+data class DiaryResponseParam(
+	val diaryId: Long,
+	val userId: Long,
+	val title: String,
+	val memoryDate: LocalDate,
+	val place: String?,
+	val content: String?,
+	val imageUrls: List<String>
+)

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/ProfileDetailResponseParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/ProfileDetailResponseParam.kt
@@ -3,7 +3,7 @@ package com.lovebird.domain.dto.query
 import com.lovebird.common.enums.AnniversaryType
 import java.time.LocalDate
 
-data class ProfileDetailParam(
+data class ProfileDetailResponseParam(
 	val userId: Long,
 	val partnerId: Long,
 	val email: String,

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/Diary.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/Diary.kt
@@ -1,0 +1,61 @@
+package com.lovebird.domain.entity
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.lovebird.domain.dto.command.DiaryUpdateRequestParam
+import com.lovebird.domain.entity.audit.AuditEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDate
+
+@Entity
+@Table(name = "diary")
+class Diary(
+	user: User,
+	title: String,
+	memoryDate: LocalDate,
+	place: String?,
+	content: String?
+) : AuditEntity() {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "diary_id")
+	val id: Long? = null
+
+	@Column(name = "title", nullable = false)
+	var title: String = title
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	@Column(name = "memory_date", nullable = false)
+	var memoryDate: LocalDate = memoryDate
+
+	@Column(name = "place")
+	var place: String? = place
+
+	@Column(name = "content")
+	var content: String? = content
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", referencedColumnName = "user_id", nullable = false)
+	val user: User = user
+
+	@OneToMany(mappedBy = "diary", fetch = FetchType.LAZY)
+	val diaryImages: List<DiaryImage> = mutableListOf()
+
+	fun update(param: DiaryUpdateRequestParam) {
+		param.title?.let { this.title = it }
+		param.memoryDate?.let { this.memoryDate = it }
+		param.place?.let { this.place = it }
+		param.content?.let { this.content = it }
+	}
+}

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/DiaryImage.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/DiaryImage.kt
@@ -1,0 +1,31 @@
+package com.lovebird.domain.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "diary_image")
+class DiaryImage(
+	diary: Diary,
+	imageUrl: String
+) {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "diary_id")
+	val id: Long? = null
+
+	@Column(name = "image_url", nullable = false)
+	val imageUrl: String = imageUrl
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "diary_id", referencedColumnName = "diary_id", nullable = false)
+	val diary: Diary = diary
+}

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/Profile.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/Profile.kt
@@ -1,7 +1,7 @@
 package com.lovebird.domain.entity
 
 import com.lovebird.common.enums.Gender
-import com.lovebird.domain.dto.command.ProfileUpdateParam
+import com.lovebird.domain.dto.command.ProfileUpdateRequestParam
 import com.lovebird.domain.entity.audit.AuditEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -62,7 +62,7 @@ class Profile(
 	@OneToMany(mappedBy = "profile", fetch = FetchType.LAZY)
 	val anniversaries: List<Anniversary> = mutableListOf()
 
-	fun update(param: ProfileUpdateParam) {
+	fun update(param: ProfileUpdateRequestParam) {
 		param.imageUrl?.let { this.imageUrl = it }
 		param.email?.let { this.email = it }
 		param.nickname?.let { this.nickname = it }

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/jpa/CoupleEntryJpaRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/jpa/CoupleEntryJpaRepository.kt
@@ -2,5 +2,7 @@ package com.lovebird.domain.repository.jpa
 
 import com.lovebird.domain.entity.CoupleEntry
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
-interface CoupleJpaRepository : JpaRepository<CoupleEntry, Long>
+@Repository
+interface CoupleEntryJpaRepository : JpaRepository<CoupleEntry, Long>

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/jpa/DiaryImageJpaRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/jpa/DiaryImageJpaRepository.kt
@@ -1,0 +1,8 @@
+package com.lovebird.domain.repository.jpa
+
+import com.lovebird.domain.entity.DiaryImage
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface DiaryImageJpaRepository : JpaRepository<DiaryImage, Long>

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/jpa/DiaryJpaRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/jpa/DiaryJpaRepository.kt
@@ -1,0 +1,8 @@
+package com.lovebird.domain.repository.jpa
+
+import com.lovebird.domain.entity.Diary
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface DiaryJpaRepository : JpaRepository<Diary, Long>

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/DiaryQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/DiaryQueryRepository.kt
@@ -1,0 +1,108 @@
+package com.lovebird.domain.repository.query
+
+import com.lovebird.domain.dto.query.DiaryListRequestParam
+import com.lovebird.domain.dto.query.DiaryResponseParam
+import com.lovebird.domain.entity.QDiary
+import com.lovebird.domain.entity.QDiary.diary
+import com.lovebird.domain.entity.QDiaryImage.diaryImage
+import com.lovebird.domain.entity.QUser.user
+import com.querydsl.core.group.GroupBy.groupBy
+import com.querydsl.core.group.GroupBy.list
+import com.querydsl.core.types.OrderSpecifier
+import com.querydsl.core.types.Projections
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.NumberPath
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Repository
+class DiaryQueryRepository(
+	private val queryFactory: JPAQueryFactory
+) {
+
+	fun findBeforeNowUsingCursor(param: DiaryListRequestParam): List<DiaryResponseParam> {
+		return queryFactory
+			.from(diary)
+			.innerJoin(user)
+			.on(eqUserId(user.id))
+			.innerJoin(diaryImage)
+			.on(eqDiary(diaryImage.diary))
+			.where(eqCouple(param.userId, param.partnerId), loeMemoryDate(param.memoryDate))
+			.orderBy(descMemoryDate(), descCreatedAt())
+			.limit(param.pageSize)
+			.transform(
+				groupBy(diary.id)
+					.list(
+						Projections.constructor(
+							DiaryResponseParam::class.java,
+							diary.id,
+							user.id,
+							diary.title,
+							diary.memoryDate,
+							diary.place,
+							diary.content,
+							list(
+								Projections.constructor(
+									String::class.java,
+									diary.diaryImages.any().imageUrl
+								)
+							)
+						)
+					)
+			)
+	}
+
+	fun findAfterNowUsingCursor(param: DiaryListRequestParam): List<DiaryResponseParam> {
+		return queryFactory
+			.from(diary)
+			.innerJoin(user)
+			.on(eqUserId(user.id))
+			.innerJoin(diaryImage)
+			.on(eqDiary(diaryImage.diary))
+			.where(eqCouple(param.userId, param.partnerId), goeMemoryDate(param.memoryDate))
+			.orderBy(ascMemoryDate(), ascCreatedAt())
+			.limit(param.pageSize)
+			.transform(
+				groupBy(diary.id)
+					.list(
+						Projections.constructor(
+							DiaryResponseParam::class.java,
+							diary.id,
+							user.id,
+							diary.title,
+							diary.memoryDate,
+							diary.place,
+							diary.content,
+							list(
+								Projections.constructor(
+									String::class.java,
+									diary.diaryImages.any().imageUrl
+								)
+							)
+						)
+					)
+			)
+	}
+
+	private fun eqDiary(diary: QDiary): BooleanExpression = diary.eq(diary)
+
+	private fun eqCouple(userId: Long, partnerId: Long): BooleanExpression = eqUserId(userId).or(eqUserId(partnerId))
+
+	private fun eqUserId(userId: Long): BooleanExpression = diary.user.id.eq(userId)
+
+	private fun eqUserId(userId: NumberPath<Long>): BooleanExpression = diary.user.id.eq(userId)
+
+	private fun loeMemoryDate(memoryDate: LocalDate): BooleanExpression = diary.memoryDate.loe(memoryDate)
+
+	private fun goeMemoryDate(memoryDate: LocalDate): BooleanExpression = diary.memoryDate.goe(memoryDate)
+
+	private fun ascMemoryDate(): OrderSpecifier<LocalDate> = diary.memoryDate.asc()
+
+	private fun descMemoryDate(): OrderSpecifier<LocalDate> = diary.memoryDate.desc()
+
+	private fun ascCreatedAt(): OrderSpecifier<LocalDateTime> = diary.createdAt.asc()
+
+	private fun descCreatedAt(): OrderSpecifier<LocalDateTime> = diary.createdAt.desc()
+}

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/ProfileQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/ProfileQueryRepository.kt
@@ -1,6 +1,6 @@
 package com.lovebird.domain.repository.query
 
-import com.lovebird.domain.dto.query.ProfileDetailParam
+import com.lovebird.domain.dto.query.ProfileDetailResponseParam
 import com.lovebird.domain.entity.QAnniversary.anniversary
 import com.lovebird.domain.entity.QCoupleEntry.coupleEntry
 import com.lovebird.domain.entity.QProfile.profile
@@ -16,11 +16,11 @@ class ProfileQueryRepository(
 	private val queryFactory: JPAQueryFactory
 ) {
 
-	fun findDetailParamByUser(user: User): ProfileDetailParam? {
+	fun findDetailParamByUser(user: User): ProfileDetailResponseParam? {
 		return queryFactory
 			.select(
 				Projections.constructor(
-					ProfileDetailParam::class.java,
+					ProfileDetailResponseParam::class.java,
 					profile.id,
 					coupleEntry.partner.id,
 					profile.email,

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/CoupleCodeReader.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/CoupleCodeReader.kt
@@ -1,13 +1,13 @@
 package com.lovebird.domain.repository.reader
 
+import com.lovebird.common.annotation.Reader
 import com.lovebird.common.enums.ReturnCode
 import com.lovebird.common.exception.LbException
 import com.lovebird.domain.entity.CoupleCode
 import com.lovebird.domain.entity.User
 import com.lovebird.domain.repository.jpa.CoupleCodeJpaRepository
-import org.springframework.stereotype.Component
 
-@Component
+@Reader
 class CoupleCodeReader(
 	private val coupleCodeJpaRepository: CoupleCodeJpaRepository
 ) {

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/DiaryReader.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/DiaryReader.kt
@@ -1,0 +1,28 @@
+package com.lovebird.domain.repository.reader
+
+import com.lovebird.common.annotation.Reader
+import com.lovebird.domain.dto.query.DiaryListRequestParam
+import com.lovebird.domain.dto.query.DiaryResponseParam
+import com.lovebird.domain.entity.Diary
+import com.lovebird.domain.repository.jpa.DiaryJpaRepository
+import com.lovebird.domain.repository.query.DiaryQueryRepository
+import jakarta.persistence.EntityNotFoundException
+
+@Reader
+class DiaryReader(
+	private val diaryJpaRepository: DiaryJpaRepository,
+	private val diaryQueryRepository: DiaryQueryRepository
+) {
+
+	fun findEntityById(id: Long): Diary {
+		return diaryJpaRepository.findById(id).orElseThrow { throw EntityNotFoundException() }
+	}
+
+	fun findBeforeNowUsingCursor(param: DiaryListRequestParam): List<DiaryResponseParam> {
+		return diaryQueryRepository.findBeforeNowUsingCursor(param)
+	}
+
+	fun findAfterNowUsingCursor(param: DiaryListRequestParam): List<DiaryResponseParam> {
+		return diaryQueryRepository.findAfterNowUsingCursor(param)
+	}
+}

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/ProfileReader.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/ProfileReader.kt
@@ -3,7 +3,7 @@ package com.lovebird.domain.repository.reader
 import com.lovebird.common.annotation.Reader
 import com.lovebird.common.enums.ReturnCode
 import com.lovebird.common.exception.LbException
-import com.lovebird.domain.dto.query.ProfileDetailParam
+import com.lovebird.domain.dto.query.ProfileDetailResponseParam
 import com.lovebird.domain.entity.Profile
 import com.lovebird.domain.entity.User
 import com.lovebird.domain.repository.jpa.ProfileJpaRepository
@@ -20,7 +20,7 @@ class ProfileReader(
 		return profileJpaRepository.findByUser(user) ?: throw EntityNotFoundException()
 	}
 
-	fun findDetailParamByUser(user: User): ProfileDetailParam {
+	fun findDetailParamByUser(user: User): ProfileDetailResponseParam {
 		return profileQueryRepository.findDetailParamByUser(user) ?: throw LbException(ReturnCode.NOT_EXIST_PROFILE)
 	}
 }

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/ProfileReader.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/ProfileReader.kt
@@ -1,5 +1,6 @@
 package com.lovebird.domain.repository.reader
 
+import com.lovebird.common.annotation.Reader
 import com.lovebird.common.enums.ReturnCode
 import com.lovebird.common.exception.LbException
 import com.lovebird.domain.dto.query.ProfileDetailParam
@@ -8,9 +9,8 @@ import com.lovebird.domain.entity.User
 import com.lovebird.domain.repository.jpa.ProfileJpaRepository
 import com.lovebird.domain.repository.query.ProfileQueryRepository
 import jakarta.persistence.EntityNotFoundException
-import org.springframework.stereotype.Component
 
-@Component
+@Reader
 class ProfileReader(
 	private val profileJpaRepository: ProfileJpaRepository,
 	private val profileQueryRepository: ProfileQueryRepository

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/writer/CoupleCodeWriter.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/writer/CoupleCodeWriter.kt
@@ -1,10 +1,10 @@
 package com.lovebird.domain.repository.writer
 
+import com.lovebird.common.annotation.Writer
 import com.lovebird.domain.entity.CoupleCode
 import com.lovebird.domain.repository.jpa.CoupleCodeJpaRepository
-import org.springframework.stereotype.Component
 
-@Component
+@Writer
 class CoupleCodeWriter(
 	private val coupleCodeJpaRepository: CoupleCodeJpaRepository
 ) {

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/writer/CoupleEntryWriter.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/writer/CoupleEntryWriter.kt
@@ -1,15 +1,15 @@
 package com.lovebird.domain.repository.writer
 
+import com.lovebird.common.annotation.Writer
 import com.lovebird.domain.entity.CoupleEntry
-import com.lovebird.domain.repository.jpa.CoupleJpaRepository
-import org.springframework.stereotype.Component
+import com.lovebird.domain.repository.jpa.CoupleEntryJpaRepository
 
-@Component
+@Writer
 class CoupleEntryWriter(
-	private val coupleJpaRepository: CoupleJpaRepository
+	private val coupleEntryJpaRepository: CoupleEntryJpaRepository
 ) {
 
 	fun saveAll(coupleEntries: List<CoupleEntry>) {
-		coupleJpaRepository.saveAll(coupleEntries)
+		coupleEntryJpaRepository.saveAll(coupleEntries)
 	}
 }

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/writer/DiaryImageWriter.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/writer/DiaryImageWriter.kt
@@ -1,0 +1,20 @@
+package com.lovebird.domain.repository.writer
+
+import com.lovebird.common.annotation.Writer
+import com.lovebird.domain.entity.Diary
+import com.lovebird.domain.entity.DiaryImage
+import com.lovebird.domain.repository.jpa.DiaryImageJpaRepository
+
+@Writer
+class DiaryImageWriter(
+	private val diaryImageJpaRepository: DiaryImageJpaRepository
+) {
+
+	fun saveAll(diary: Diary, imageUrls: List<String>) {
+		diaryImageJpaRepository.saveAll(imageUrls.map { DiaryImage(diary, it) })
+	}
+
+	fun deleteAll(diary: Diary) {
+		diaryImageJpaRepository.deleteAll(diary.diaryImages)
+	}
+}

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/writer/DiaryWriter.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/writer/DiaryWriter.kt
@@ -1,0 +1,24 @@
+package com.lovebird.domain.repository.writer
+
+import com.lovebird.common.annotation.Writer
+import com.lovebird.domain.dto.command.DiaryUpdateRequestParam
+import com.lovebird.domain.entity.Diary
+import com.lovebird.domain.repository.jpa.DiaryJpaRepository
+
+@Writer
+class DiaryWriter(
+	private val diaryJpaRepository: DiaryJpaRepository
+) {
+
+	fun save(diary: Diary) {
+		diaryJpaRepository.save(diary)
+	}
+
+	fun update(diary: Diary, param: DiaryUpdateRequestParam) {
+		diary.update(param)
+	}
+
+	fun delete(diary: Diary) {
+		diaryJpaRepository.delete(diary)
+	}
+}

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/writer/ProfileWriter.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/writer/ProfileWriter.kt
@@ -1,7 +1,7 @@
 package com.lovebird.domain.repository.writer
 
 import com.lovebird.common.annotation.Writer
-import com.lovebird.domain.dto.command.ProfileUpdateParam
+import com.lovebird.domain.dto.command.ProfileUpdateRequestParam
 import com.lovebird.domain.entity.Profile
 import com.lovebird.domain.repository.jpa.ProfileJpaRepository
 
@@ -14,7 +14,7 @@ class ProfileWriter(
 		profileJpaRepository.save(profile)
 	}
 
-	fun update(profile: Profile, param: ProfileUpdateParam) {
+	fun update(profile: Profile, param: ProfileUpdateRequestParam) {
 		profile.update(param)
 	}
 }

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/writer/ProfileWriter.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/writer/ProfileWriter.kt
@@ -1,11 +1,11 @@
 package com.lovebird.domain.repository.writer
 
+import com.lovebird.common.annotation.Writer
 import com.lovebird.domain.dto.command.ProfileUpdateParam
 import com.lovebird.domain.entity.Profile
 import com.lovebird.domain.repository.jpa.ProfileJpaRepository
-import org.springframework.stereotype.Component
 
-@Component
+@Writer
 class ProfileWriter(
 	private val profileJpaRepository: ProfileJpaRepository
 ) {


### PR DESCRIPTION
> ### Issue Number

#14 

> ### Description

- diary, diary_image 엔티티 구현
- diary CRUD 쿼리 구현 (페이지네이션 포함)
- AES 암호화 Bean 구현

> ### Core Code

```kotlin
	fun findBeforeNowUsingCursor(param: DiaryListRequestParam): List<DiaryResponseParam> {
		return queryFactory
			.from(diary)
			.innerJoin(user)
			.on(eqUserId(user.id))
			.innerJoin(diaryImage)
			.on(eqDiary(diaryImage.diary))
			.where(eqCouple(param.userId, param.partnerId), loeMemoryDate(param.memoryDate))
			.orderBy(descMemoryDate(), descCreatedAt())
			.limit(param.pageSize)
			.transform(
				groupBy(diary.id)
					.list(
						Projections.constructor(
							DiaryResponseParam::class.java,
							diary.id,
							user.id,
							diary.title,
							diary.memoryDate,
							diary.place,
							diary.content,
							list(
								Projections.constructor(
									String::class.java,
									diary.diaryImages.any().imageUrl
								)
							)
						)
					)
			)
	}
```

- 커서 페이지네이션으로 구현

> ### etc
