### PR TITLE
Feature | #14 | @lcomment | 일기 페이지네이션 조회 구현

### DIFF
--- a/lovebird-api/src/main/kotlin/com/lovebird/api/controller/diary/DiaryController.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/controller/diary/DiaryController.kt
@@ -4,6 +4,7 @@ import com.lovebird.api.dto.request.diary.DiaryCreateRequest
 import com.lovebird.api.dto.request.diary.DiaryListRequest
 import com.lovebird.api.dto.request.diary.DiaryUpdateRequest
 import com.lovebird.api.dto.response.diary.DiaryDetailResponse
+import com.lovebird.api.dto.response.diary.DiaryListResponse
 import com.lovebird.api.dto.response.diary.DiarySimpleListResponse
 import com.lovebird.api.service.diary.DiaryService
 import com.lovebird.common.response.ApiResponse
@@ -36,12 +37,20 @@ class DiaryController(
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success())
 	}
 
-	@GetMapping
+	@GetMapping("/memory-date")
 	fun findAllByMemoryDate(
 		@AuthorizedUser user: User,
 		@ModelAttribute request: DiaryListRequest.SearchByMemoryDateRequest
 	): ApiResponse<DiarySimpleListResponse> {
 		return ApiResponse.success(diaryService.findAllByMemoryDate(request, user))
+	}
+
+	@GetMapping("/cursor")
+	fun findAllByCursor(
+		@AuthorizedUser user: User,
+		@ModelAttribute request: DiaryListRequest.SearchByCursorRequest
+	): ApiResponse<DiaryListResponse> {
+		return ApiResponse.success(diaryService.findPageByCursor(request, user))
 	}
 
 	@GetMapping("/{id}")

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/diary/DiaryListRequest.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/diary/DiaryListRequest.kt
@@ -1,5 +1,7 @@
 package com.lovebird.api.dto.request.diary
 
+import com.lovebird.common.enums.DiarySearchType
+import com.lovebird.domain.dto.query.DiaryListRequestParam
 import com.lovebird.domain.dto.query.DiarySimpleRequestParam
 import java.time.LocalDate
 
@@ -14,6 +16,23 @@ sealed class DiaryListRequest(
 				userId = userId,
 				partnerId = partnerId,
 				memoryDate = memoryDate
+			)
+		}
+	}
+
+	data class SearchByCursorRequest(
+		override val memoryDate: LocalDate,
+		val searchType: DiarySearchType,
+		val diaryId: Long,
+		val pageSize: Long
+	) : DiaryListRequest(memoryDate) {
+		fun toParam(userId: Long, partnerId: Long?): DiaryListRequestParam {
+			return DiaryListRequestParam(
+				userId = userId,
+				partnerId = partnerId,
+				diaryId = diaryId,
+				memoryDate = memoryDate,
+				pageSize = pageSize
 			)
 		}
 	}

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/response/diary/DiaryListResponse.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/response/diary/DiaryListResponse.kt
@@ -1,5 +1,11 @@
 package com.lovebird.api.dto.response.diary
 
+import com.lovebird.domain.dto.query.DiaryResponseParam
+import java.time.LocalDate
+
 data class DiaryListResponse(
-	val diaries: List<DiaryDetailResponse>
+	val diaries: List<DiaryResponseParam>?,
+	val totalCount: Int = diaries?.size ?: 0,
+	val diaryId: Long? = diaries?.last()?.diaryId,
+	val memoryDate: LocalDate? = diaries?.last()?.memoryDate
 )

--- a/lovebird-common/src/main/kotlin/com/lovebird/common/enums/DiarySearchType.kt
+++ b/lovebird-common/src/main/kotlin/com/lovebird/common/enums/DiarySearchType.kt
@@ -1,0 +1,7 @@
+package com.lovebird.common.enums
+
+enum class DiarySearchType {
+
+	BEFORE,
+	AFTER
+}

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/DiaryListRequestParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/DiaryListRequestParam.kt
@@ -4,7 +4,8 @@ import java.time.LocalDate
 
 data class DiaryListRequestParam(
 	val userId: Long,
-	val partnerId: Long,
+	val partnerId: Long?,
+	val diaryId: Long,
 	val memoryDate: LocalDate,
 	val pageSize: Long
 )

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/DiaryImage.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/DiaryImage.kt
@@ -12,9 +12,12 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
 @Entity
-@Table(name = "diary_image", indexes = [
-	Index(name = "fk_diary_image_diary_id", columnList = "diary_id")
-])
+@Table(
+	name = "diary_image",
+	indexes = [
+		Index(name = "fk_diary_image_diary_id", columnList = "diary_id")
+	]
+)
 class DiaryImage(
 	diary: Diary,
 	imageUrl: String

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/DiaryImage.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/DiaryImage.kt
@@ -6,12 +6,15 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
 @Entity
-@Table(name = "diary_image")
+@Table(name = "diary_image", indexes = [
+	Index(name = "fk_diary_image_diary_id", columnList = "diary_id")
+])
 class DiaryImage(
 	diary: Diary,
 	imageUrl: String

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/DiaryQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/DiaryQueryRepository.kt
@@ -31,8 +31,12 @@ class DiaryQueryRepository(
 			.on(eqUserId(user.id))
 			.innerJoin(diaryImage)
 			.on(eqDiary(diaryImage.diary))
-			.where(eqCouple(param.userId, param.partnerId), loeMemoryDate(param.memoryDate))
-			.orderBy(descMemoryDate(), descCreatedAt())
+			.where(
+				eqCouple(param.userId, param.partnerId),
+				eqMemoryDateAndGtDiaryId(param.memoryDate, param.diaryId),
+				ltMemoryDate(param.memoryDate)
+			)
+			.orderBy(descMemoryDate(), ascDiaryId())
 			.limit(param.pageSize)
 			.transform(
 				groupBy(diary.id)
@@ -63,8 +67,12 @@ class DiaryQueryRepository(
 			.on(eqUserId(user.id))
 			.innerJoin(diaryImage)
 			.on(eqDiary(diaryImage.diary))
-			.where(eqCouple(param.userId, param.partnerId), goeMemoryDate(param.memoryDate))
-			.orderBy(ascMemoryDate(), ascCreatedAt())
+			.where(
+				eqCouple(param.userId, param.partnerId),
+				eqMemoryDateAndGtDiaryId(param.memoryDate, param.diaryId),
+				gtMemoryDate(param.memoryDate)
+			)
+			.orderBy(ascMemoryDate(), ascDiaryId())
 			.limit(param.pageSize)
 			.transform(
 				groupBy(diary.id)
@@ -106,7 +114,7 @@ class DiaryQueryRepository(
 			.innerJoin(user)
 			.on(eqUserId(user.id))
 			.where(eqCouple(param.userId, param.partnerId), eqMemoryDate(param.memoryDate))
-			.orderBy(descCreatedAt())
+			.orderBy(ascDiaryId())
 			.fetch()
 	}
 
@@ -126,17 +134,21 @@ class DiaryQueryRepository(
 
 	private fun eqUserId(userId: NumberPath<Long>): BooleanExpression = diary.user.id.eq(userId)
 
+	private fun eqMemoryDateAndGtDiaryId(memoryDate: LocalDate, diaryId: Long): BooleanExpression {
+		return eqMemoryDate(memoryDate).and(gtDiaryId(diaryId))
+	}
+
 	private fun eqMemoryDate(memoryDate: LocalDate): BooleanExpression = diary.memoryDate.eq(memoryDate)
 
-	private fun loeMemoryDate(memoryDate: LocalDate): BooleanExpression = diary.memoryDate.loe(memoryDate)
+	private fun gtDiaryId(diaryId: Long): BooleanExpression = diary.id.gt(diaryId)
 
-	private fun goeMemoryDate(memoryDate: LocalDate): BooleanExpression = diary.memoryDate.goe(memoryDate)
+	private fun ltMemoryDate(memoryDate: LocalDate): BooleanExpression = diary.memoryDate.lt(memoryDate)
+
+	private fun gtMemoryDate(memoryDate: LocalDate): BooleanExpression = diary.memoryDate.gt(memoryDate)
+
+	private fun ascDiaryId(): OrderSpecifier<Long> = diary.id.asc()
 
 	private fun ascMemoryDate(): OrderSpecifier<LocalDate> = diary.memoryDate.asc()
 
 	private fun descMemoryDate(): OrderSpecifier<LocalDate> = diary.memoryDate.desc()
-
-	private fun ascCreatedAt(): OrderSpecifier<LocalDateTime> = diary.createdAt.asc()
-
-	private fun descCreatedAt(): OrderSpecifier<LocalDateTime> = diary.createdAt.desc()
 }

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/DiaryQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/DiaryQueryRepository.kt
@@ -28,8 +28,6 @@ class DiaryQueryRepository(
 			.from(diary)
 			.innerJoin(user)
 			.on(eqUserId(user.id))
-			.innerJoin(diaryImage)
-			.on(eqDiary(diaryImage.diary))
 			.where(
 				eqCouple(param.userId, param.partnerId),
 				eqMemoryDateAndGtDiaryId(param.memoryDate, param.diaryId),
@@ -51,7 +49,7 @@ class DiaryQueryRepository(
 							list(
 								Projections.constructor(
 									String::class.java,
-									diary.diaryImages.any().imageUrl
+									diaryImage.imageUrl
 								)
 							)
 						)
@@ -64,8 +62,6 @@ class DiaryQueryRepository(
 			.from(diary)
 			.innerJoin(user)
 			.on(eqUserId(user.id))
-			.innerJoin(diaryImage)
-			.on(eqDiary(diaryImage.diary))
 			.where(
 				eqCouple(param.userId, param.partnerId),
 				eqMemoryDateAndGtDiaryId(param.memoryDate, param.diaryId),
@@ -87,7 +83,7 @@ class DiaryQueryRepository(
 							list(
 								Projections.constructor(
 									String::class.java,
-									diary.diaryImages.any().imageUrl
+									diaryImage.imageUrl
 								)
 							)
 						)

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/DiaryQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/DiaryQueryRepository.kt
@@ -130,7 +130,7 @@ class DiaryQueryRepository(
 	private fun eqUserId(userId: NumberPath<Long>): BooleanExpression = diary.user.id.eq(userId)
 
 	private fun eqMemoryDateAndGtDiaryId(memoryDate: LocalDate, diaryId: Long): BooleanExpression {
-		return eqMemoryDate(memoryDate).and(gtDiaryId(diaryId))
+		return gtDiaryId(diaryId).and(eqMemoryDate(memoryDate))
 	}
 
 	private fun eqMemoryDate(memoryDate: LocalDate): BooleanExpression = diary.memoryDate.eq(memoryDate)

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/DiaryQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/DiaryQueryRepository.kt
@@ -17,7 +17,6 @@ import com.querydsl.core.types.dsl.NumberPath
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @Repository
 class DiaryQueryRepository(


### PR DESCRIPTION
> ### Issue Number

#14 

> ### Description

- diary image에 인덱스 부여
  - index column : diary_id
  - index name : fk_diary_image_diary_id
- diary 페이지네이션 구현
  - diaryId에 0 or -1을 넣고 request를 보내 모든 레코드가 해당 조건(gtDiaryId)을 통과하도록 구성했다.
  - 데이터는 memoryDate 기준 내림차순 정렬, 같은 memoryDate의 데이터끼리는 diaryId 기준 오름차순 정렬한다.
> ### Core Code

```kotlin
. . .
			.where(
				eqCouple(param.userId, param.partnerId),
				eqMemoryDateAndGtDiaryId(param.memoryDate, param.diaryId),
				gtMemoryDate(param.memoryDate)
			)
			.orderBy(ascMemoryDate(), ascDiaryId())
			.limit(param.pageSize)
. . .
```

1. 처음 조회 시 (=오늘 날짜 조회)
- 요청
  - diaryId : 0 or -1
  - memoryDate : 오늘 날짜
- 조회 데이터 
  - 요청 받은 날짜와 동일하고, 요청 받은 아이디보다 큰 아이디를 가진 데이터 (`eqMemoryDateAndGtDiaryId`)
  - 요청 받은 날짜 이후, 혹은 이전의 데이터 (`ltMemoryDate` or `gtMemoryDate`)
  - 데이터 갯수 : pageSize

2. 처음 이후의 조회 시
- 요청
  - diaryId : 이전 조회에서 응답으로 받은 diaryId
  - memoryDate : 이전 조회에서 응답으로 받은 memoryDate
- 조회 데이터 
  - 요청 받은 날짜와 동일하고, 요청 받은 아이디보다 큰 아이디를 가진 데이터 (`eqMemoryDateAndGtDiaryId`)
  - 요청 받은 날짜 이후, 혹은 이전의 데이터 (`ltMemoryDate` or `gtMemoryDate`)
  - 데이터 갯수 : pageSize


> ### etc

- 인덱스 네이밍 관련해서 노션에 정리해두겠습니다.
- fk_diary_image_diary_id를 제외한 다른 인덱스를 부여하지 않고 최대한 diary의 PK를 활용하였고, pageSize를 보장하여 쿼리를 작성했습니다.