### PR TITLE
Feature | #28 | @YongsHub | 캘린더 년도 및 월별 전체 조회 로직 구현

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ javaVersion=19
 ktlintVersion=11.6.0
 
 ### Spring Dependency Versions ###
-springBootVersion=3.2.0
+springBootVersion=3.1.5
 springDependencyManagementVersion=1.1.4
 
 ### External Dependency versions ###

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/controller/calendar/CalendarController.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/controller/calendar/CalendarController.kt
@@ -1,11 +1,13 @@
 package com.lovebird.api.controller.calendar
 
+import com.lovebird.api.dto.request.calendar.CalendarListRequest
 import com.lovebird.api.dto.response.calendar.CalendarDetailResponse
 import com.lovebird.api.dto.response.calendar.CalendarListResponse
 import com.lovebird.api.service.calendar.CalendarService
 import com.lovebird.common.response.ApiResponse
 import com.lovebird.domain.entity.User
 import com.lovebird.security.annotation.AuthorizedUser
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -22,12 +24,11 @@ class CalendarController(
 		return ApiResponse.success(calendarService.findById(id))
 	}
 
-	@GetMapping("/{year}/{month}")
+	@GetMapping
 	fun getCalendarsByMonth(
-		@PathVariable year: Int,
-		@PathVariable month: Int,
+		@Valid calendarListRequest: CalendarListRequest,
 		@AuthorizedUser user: User
 	): ApiResponse<CalendarListResponse> {
-		return ApiResponse.success(calendarService.findCalendarsByMonthAndUser(year, month, user))
+		return ApiResponse.success(calendarService.findCalendarsByMonthAndUser(calendarListRequest.toParam(user)))
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/controller/calendar/CalendarController.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/controller/calendar/CalendarController.kt
@@ -9,6 +9,7 @@ import com.lovebird.domain.entity.User
 import com.lovebird.security.annotation.AuthorizedUser
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -26,7 +27,8 @@ class CalendarController(
 
 	@GetMapping
 	fun getCalendarsByMonth(
-		@Valid calendarListRequest: CalendarListRequest,
+		@Valid @ModelAttribute
+		calendarListRequest: CalendarListRequest,
 		@AuthorizedUser user: User
 	): ApiResponse<CalendarListResponse> {
 		return ApiResponse.success(calendarService.findCalendarsByMonthAndUser(calendarListRequest.toParam(user)))

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/controller/calendar/CalendarController.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/controller/calendar/CalendarController.kt
@@ -1,8 +1,11 @@
 package com.lovebird.api.controller.calendar
 
 import com.lovebird.api.dto.response.calendar.CalendarDetailResponse
+import com.lovebird.api.dto.response.calendar.CalendarListResponse
 import com.lovebird.api.service.calendar.CalendarService
 import com.lovebird.common.response.ApiResponse
+import com.lovebird.domain.entity.User
+import com.lovebird.security.annotation.AuthorizedUser
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -17,5 +20,14 @@ class CalendarController(
 	@GetMapping("/{id}")
 	fun getCalendarById(@PathVariable id: Long): ApiResponse<CalendarDetailResponse> {
 		return ApiResponse.success(calendarService.findById(id))
+	}
+
+	@GetMapping("/{year}/{month}")
+	fun getCalendarsByMonth(
+		@PathVariable year: Int,
+		@PathVariable month: Int,
+		@AuthorizedUser user: User
+	): ApiResponse<CalendarListResponse> {
+		return ApiResponse.success(calendarService.findCalendarsByMonthAndUser(year, month, user))
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/param/calendar/CalendarListParam.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/param/calendar/CalendarListParam.kt
@@ -1,5 +1,6 @@
 package com.lovebird.api.dto.param.calendar
 
+import com.lovebird.domain.dto.query.CalenderListRequestParam
 import com.lovebird.domain.entity.User
 
 data class CalendarListParam(
@@ -7,4 +8,11 @@ data class CalendarListParam(
 	val month: Int,
 	val user: User
 ) {
+	fun toRequestParam(partner: User): CalenderListRequestParam {
+		return CalenderListRequestParam(year, month, user.id!!, partner.id)
+	}
+
+	fun toRequestParam(): CalenderListRequestParam {
+		return CalenderListRequestParam(year, month, user.id!!, null)
+	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/param/calendar/CalendarListParam.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/param/calendar/CalendarListParam.kt
@@ -4,8 +4,8 @@ import com.lovebird.domain.dto.query.CalenderListRequestParam
 import com.lovebird.domain.entity.User
 
 data class CalendarListParam(
-	val year: Int,
-	val month: Int,
+	val year: Int?,
+	val month: Int?,
 	val user: User
 ) {
 	fun toRequestParam(partner: User): CalenderListRequestParam {

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/param/calendar/CalendarListParam.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/param/calendar/CalendarListParam.kt
@@ -1,0 +1,10 @@
+package com.lovebird.api.dto.param.calendar
+
+import com.lovebird.domain.entity.User
+
+data class CalendarListParam(
+	val year: Int,
+	val month: Int,
+	val user: User
+) {
+}

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarListRequest.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarListRequest.kt
@@ -2,13 +2,10 @@ package com.lovebird.api.dto.request.calendar
 
 import com.lovebird.api.dto.param.calendar.CalendarListParam
 import com.lovebird.domain.entity.User
-import jakarta.validation.constraints.NotNull
 
 data class CalendarListRequest(
-	@NotNull
-	val year: Int,
-	@NotNull
-	val month: Int
+	val year: Int?,
+	val month: Int?
 ) {
 	fun toParam(user: User): CalendarListParam {
 		return CalendarListParam(year, month, user)

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarListRequest.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarListRequest.kt
@@ -1,0 +1,16 @@
+package com.lovebird.api.dto.request.calendar
+
+import com.lovebird.api.dto.param.calendar.CalendarListParam
+import com.lovebird.domain.entity.User
+import jakarta.validation.constraints.NotNull
+
+data class CalendarListRequest(
+	@NotNull
+	val year: Int,
+	@NotNull
+	val month: Int
+) {
+	fun toParam(user: User): CalendarListParam {
+		return CalendarListParam(year, month, user)
+	}
+}

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/response/calendar/CalendarListResponse.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/response/calendar/CalendarListResponse.kt
@@ -1,0 +1,13 @@
+package com.lovebird.api.dto.response.calendar
+
+import com.lovebird.domain.dto.query.CalendarListResponseParam
+
+data class CalendarListResponse(
+	val calendars: List<CalendarListResponseParam>
+) {
+	companion object {
+		fun of(calendars: List<CalendarListResponseParam>): CalendarListResponse {
+			return CalendarListResponse(calendars)
+		}
+	}
+}

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/response/calendar/CalendarListResponse.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/response/calendar/CalendarListResponse.kt
@@ -4,11 +4,11 @@ import com.lovebird.domain.dto.query.CalendarListResponseParam
 
 data class CalendarListResponse(
 	val calendars: List<CalendarListResponseParam>,
-	val totalCount: Int
+	val totalCount: Int = calendars.size
 ) {
 	companion object {
 		fun of(calendars: List<CalendarListResponseParam>): CalendarListResponse {
-			return CalendarListResponse(calendars, calendars.size)
+			return CalendarListResponse(calendars)
 		}
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/response/calendar/CalendarListResponse.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/response/calendar/CalendarListResponse.kt
@@ -3,11 +3,12 @@ package com.lovebird.api.dto.response.calendar
 import com.lovebird.domain.dto.query.CalendarListResponseParam
 
 data class CalendarListResponse(
-	val calendars: List<CalendarListResponseParam>
+	val calendars: List<CalendarListResponseParam>,
+	val totalCount: Int
 ) {
 	companion object {
 		fun of(calendars: List<CalendarListResponseParam>): CalendarListResponse {
-			return CalendarListResponse(calendars)
+			return CalendarListResponse(calendars, calendars.size)
 		}
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
@@ -1,5 +1,6 @@
 package com.lovebird.api.service.calendar
 
+import com.lovebird.api.dto.param.calendar.CalendarListParam
 import com.lovebird.api.dto.response.calendar.CalendarDetailResponse
 import com.lovebird.api.dto.response.calendar.CalendarListResponse
 import com.lovebird.common.enums.ReturnCode
@@ -29,13 +30,17 @@ class CalendarService(
 	}
 
 	@Transactional(readOnly = true)
-	fun findCalendarsByMonthAndUser(year: Int, month: Int, user: User): CalendarListResponse {
-		val coupleEntry: CoupleEntry? = coupleEntryReader.findByUser(user)
+	fun findCalendarsByMonthAndUser(calendarListParam: CalendarListParam): CalendarListResponse {
+		val coupleEntry: CoupleEntry? = coupleEntryReader.findByUser(calendarListParam.user)
 
 		if (coupleEntry != null) {
 			val partner: User = coupleEntry.partner
 			val calendars: List<CalendarListResponseParam> = calendarReader
-				.findCalendarsByDateAndUserIdAndPartnerId(year, month, user.id!!, partner.id!!)
+				.findCalendarsByDateAndUserIdAndPartnerId(
+					calendarListParam.year,
+					calendarListParam.month,
+					calendarListParam.user.id!!,
+					partner.id!!)
 
 			return CalendarListResponse.of(calendars)
 		}

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
@@ -3,8 +3,6 @@ package com.lovebird.api.service.calendar
 import com.lovebird.api.dto.param.calendar.CalendarListParam
 import com.lovebird.api.dto.response.calendar.CalendarDetailResponse
 import com.lovebird.api.dto.response.calendar.CalendarListResponse
-import com.lovebird.common.enums.ReturnCode
-import com.lovebird.common.exception.LbException
 import com.lovebird.domain.dto.query.CalendarListResponseParam
 import com.lovebird.domain.entity.Calendar
 import com.lovebird.domain.entity.CoupleEntry
@@ -36,15 +34,10 @@ class CalendarService(
 		if (coupleEntry != null) {
 			val partner: User = coupleEntry.partner
 			val calendars: List<CalendarListResponseParam> = calendarReader
-				.findCalendarsByDateAndUserIdAndPartnerId(
-					calendarListParam.year,
-					calendarListParam.month,
-					calendarListParam.user.id!!,
-					partner.id!!)
+				.findCalendarsByDate(calendarListParam.toRequestParam(partner))
 
 			return CalendarListResponse.of(calendars)
 		}
-
-		throw LbException(ReturnCode.CALENDAR_BUSINESS_ERROR)
+		return CalendarListResponse.of(calendarReader.findCalendarsByDate(calendarListParam.toRequestParam()))
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
@@ -1,8 +1,15 @@
 package com.lovebird.api.service.calendar
 
 import com.lovebird.api.dto.response.calendar.CalendarDetailResponse
+import com.lovebird.api.dto.response.calendar.CalendarListResponse
+import com.lovebird.common.enums.ReturnCode
+import com.lovebird.common.exception.LbException
+import com.lovebird.domain.dto.query.CalendarListResponseParam
 import com.lovebird.domain.entity.Calendar
+import com.lovebird.domain.entity.CoupleEntry
+import com.lovebird.domain.entity.User
 import com.lovebird.domain.repository.reader.CalendarReader
+import com.lovebird.domain.repository.reader.CoupleEntryReader
 import com.lovebird.domain.repository.writer.CalendarWriter
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -10,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class CalendarService(
 	private val calendarReader: CalendarReader,
+	private val coupleEntryReader: CoupleEntryReader,
 	private val calendarWriter: CalendarWriter
 ) {
 
@@ -18,5 +26,20 @@ class CalendarService(
 		val calendar: Calendar = calendarReader.findEntityById(id)
 
 		return CalendarDetailResponse.of(calendar)
+	}
+
+	@Transactional(readOnly = true)
+	fun findCalendarsByMonthAndUser(year: Int, month: Int, user: User): CalendarListResponse {
+		val coupleEntry: CoupleEntry? = coupleEntryReader.findByUser(user)
+
+		if (coupleEntry != null) {
+			val partner: User = coupleEntry.partner
+			val calendars: List<CalendarListResponseParam> = calendarReader
+				.findCalendarsByDateAndUserIdAndPartnerId(year, month, user.id!!, partner.id!!)
+
+			return CalendarListResponse.of(calendars)
+		}
+
+		throw LbException(ReturnCode.CALENDAR_BUSINESS_ERROR)
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
@@ -28,16 +28,17 @@ class CalendarService(
 	}
 
 	@Transactional(readOnly = true)
-	fun findCalendarsByMonthAndUser(calendarListParam: CalendarListParam): CalendarListResponse {
-		val coupleEntry: CoupleEntry? = coupleEntryReader.findByUser(calendarListParam.user)
+	fun findCalendarsByMonthAndUser(param: CalendarListParam): CalendarListResponse {
+		val coupleEntry: CoupleEntry? = coupleEntryReader.findByUser(param.user)
 
-		if (coupleEntry != null) {
+		return if (coupleEntry != null) {
 			val partner: User = coupleEntry.partner
 			val calendars: List<CalendarListResponseParam> = calendarReader
-				.findCalendarsByDate(calendarListParam.toRequestParam(partner))
+				.findCalendarsByDate(param.toRequestParam(partner))
 
-			return CalendarListResponse.of(calendars)
+			CalendarListResponse.of(calendars)
+		} else {
+			CalendarListResponse.of(calendarReader.findCalendarsByDate(param.toRequestParam()))
 		}
-		return CalendarListResponse.of(calendarReader.findCalendarsByDate(calendarListParam.toRequestParam()))
 	}
 }

--- a/lovebird-common/src/main/kotlin/com/lovebird/common/enums/ReturnCode.kt
+++ b/lovebird-common/src/main/kotlin/com/lovebird/common/enums/ReturnCode.kt
@@ -19,6 +19,9 @@ enum class ReturnCode(val code: String, val message: String) {
 	// 커플 관련
 	ALREADY_EXIST_COUPLE("1300", "이미 커플 연동을 한 유저입니다."),
 
+	// 캘린더 관련
+	CALENDAR_BUSINESS_ERROR("1400", "캘린더 일정을 조회하는데 문제가 발생했습니다."),
+
 	// 클라이언트 에러
 	WRONG_PARAMETER("8000", "잘못된 파라미터 입니다."),
 

--- a/lovebird-common/src/main/kotlin/com/lovebird/common/enums/ReturnCode.kt
+++ b/lovebird-common/src/main/kotlin/com/lovebird/common/enums/ReturnCode.kt
@@ -19,9 +19,6 @@ enum class ReturnCode(val code: String, val message: String) {
 	// 커플 관련
 	ALREADY_EXIST_COUPLE("1300", "이미 커플 연동을 한 유저입니다."),
 
-	// 캘린더 관련
-	CALENDAR_BUSINESS_ERROR("1400", "캘린더 일정을 조회하는데 문제가 발생했습니다."),
-
 	// 클라이언트 에러
 	WRONG_PARAMETER("8000", "잘못된 파라미터 입니다."),
 

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/CalendarListResponseParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/CalendarListResponseParam.kt
@@ -7,6 +7,7 @@ import java.time.LocalTime
 
 data class CalendarListResponseParam(
 	val id: Long,
+	val userId: Long,
 	val title: String,
 	val memo: String?,
 	val startDate: LocalDate,

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/CalendarListResponseParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/CalendarListResponseParam.kt
@@ -1,0 +1,18 @@
+package com.lovebird.domain.dto.query
+
+import com.lovebird.common.enums.Alarm
+import com.lovebird.common.enums.Color
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class CalendarListResponseParam(
+	val id: Long,
+	val title: String,
+	val memo: String?,
+	val startDate: LocalDate,
+	val endDate: LocalDate?,
+	val startTime: LocalTime?,
+	val endTime: LocalTime?,
+	val color: Enum<Color>,
+	val alarm: Enum<Alarm>
+)

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/CalenderListRequestParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/CalenderListRequestParam.kt
@@ -1,0 +1,8 @@
+package com.lovebird.domain.dto.query
+
+data class CalenderListRequestParam(
+	val year: Int,
+	val month: Int,
+	val userId: Long,
+	val partnerId: Long?
+)

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/CalenderListRequestParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/CalenderListRequestParam.kt
@@ -1,8 +1,8 @@
 package com.lovebird.domain.dto.query
 
 data class CalenderListRequestParam(
-	val year: Int,
-	val month: Int,
+	val year: Int?,
+	val month: Int?,
 	val userId: Long,
 	val partnerId: Long?
 )

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/CalendarQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/CalendarQueryRepository.kt
@@ -23,6 +23,7 @@ class CalendarQueryRepository(
 				Projections.constructor(
 					CalendarListResponseParam::class.java,
 					calendar.id,
+					calendar.user.id,
 					calendar.title,
 					calendar.memo,
 					calendar.startDate,

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/CalendarQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/CalendarQueryRepository.kt
@@ -1,6 +1,7 @@
 package com.lovebird.domain.repository.query
 
 import com.lovebird.domain.dto.query.CalendarListResponseParam
+import com.lovebird.domain.dto.query.CalenderListRequestParam
 import com.lovebird.domain.entity.QCalendar.calendar
 import com.querydsl.core.types.Projections
 import com.querydsl.core.types.dsl.BooleanExpression
@@ -13,11 +14,7 @@ class CalendarQueryRepository(
 ) {
 
 	fun findCalendarsByDateAndUserIdAndPartnerId(
-		year: Int,
-		month: Int,
-		userId: Long,
-		partnerId: Long
-	): List<CalendarListResponseParam> {
+		calenderListRequestParam: CalenderListRequestParam): List<CalendarListResponseParam> {
 		return queryFactory
 			.select(
 				Projections.constructor(
@@ -35,7 +32,7 @@ class CalendarQueryRepository(
 				)
 			)
 			.from(calendar)
-			.where(eqUserIdOrEqPartnerId(userId, partnerId), eqYearAndMonth(year, month))
+			.where(eqUserIdOrEqPartnerId(calenderListRequestParam.userId, calenderListRequestParam.partnerId!!), eqYearAndMonth(calenderListRequestParam.year, calenderListRequestParam.month))
 			.orderBy(calendar.startDate.asc())
 			.fetch()
 	}

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/CalendarQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/CalendarQueryRepository.kt
@@ -1,0 +1,49 @@
+package com.lovebird.domain.repository.query
+
+import com.lovebird.domain.dto.query.CalendarListResponseParam
+import com.lovebird.domain.entity.QCalendar.calendar
+import com.querydsl.core.types.Projections
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class CalendarQueryRepository(
+	private val queryFactory: JPAQueryFactory
+) {
+
+	fun findCalendarsByDateAndUserIdAndPartnerId(
+		year: Int,
+		month: Int,
+		userId: Long,
+		partnerId: Long
+	): List<CalendarListResponseParam> {
+		return queryFactory
+			.select(
+				Projections.constructor(
+					CalendarListResponseParam::class.java,
+					calendar.id,
+					calendar.title,
+					calendar.memo,
+					calendar.startDate,
+					calendar.endDate,
+					calendar.startTime,
+					calendar.endTime,
+					calendar.color,
+					calendar.alarm
+				)
+			)
+			.from(calendar)
+			.where(eqUserIdOrEqPartnerId(userId, partnerId), eqYearAndMonth(year, month))
+			.orderBy(calendar.startDate.asc())
+			.fetch()
+	}
+
+	private fun eqUserIdOrEqPartnerId(userId: Long, partnerId: Long): BooleanExpression {
+		return calendar.user.id.eq(userId).or(calendar.user.id.eq(partnerId))
+	}
+
+	private fun eqYearAndMonth(year: Int, month: Int): BooleanExpression {
+		return calendar.startDate.year().eq(year).and(calendar.startDate.month().eq(month))
+	}
+}

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/CalendarQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/CalendarQueryRepository.kt
@@ -13,8 +13,7 @@ class CalendarQueryRepository(
 	private val queryFactory: JPAQueryFactory
 ) {
 
-	fun findCalendarsByDateAndUserIdAndPartnerId(
-		calenderListRequestParam: CalenderListRequestParam): List<CalendarListResponseParam> {
+	fun findCalendarsByDateAndUserIdAndPartnerId(param: CalenderListRequestParam): List<CalendarListResponseParam> {
 		return queryFactory
 			.select(
 				Projections.constructor(
@@ -32,8 +31,8 @@ class CalendarQueryRepository(
 				)
 			)
 			.from(calendar)
-			.where(eqUserIdOrEqPartnerId(calenderListRequestParam))
-			.where(eqYearAndMonth(calenderListRequestParam.year, calenderListRequestParam.month))
+			.where(eqUserIdOrEqPartnerId(param))
+			.where(eqYearAndMonth(param))
 			.orderBy(calendar.startDate.asc())
 			.fetch()
 	}
@@ -44,7 +43,7 @@ class CalendarQueryRepository(
 
 	private fun eqUserId(userId: Long?): BooleanExpression = calendar.user.id.eq(userId)
 
-	private fun eqYearAndMonth(year: Int, month: Int): BooleanExpression {
-		return calendar.startDate.year().eq(year).and(calendar.startDate.month().eq(month))
+	private fun eqYearAndMonth(param: CalenderListRequestParam): BooleanExpression {
+		return calendar.startDate.year().eq(param.year).and(calendar.startDate.month().eq(param.month))
 	}
 }

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/CalendarQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/CalendarQueryRepository.kt
@@ -32,14 +32,17 @@ class CalendarQueryRepository(
 				)
 			)
 			.from(calendar)
-			.where(eqUserIdOrEqPartnerId(calenderListRequestParam.userId, calenderListRequestParam.partnerId!!), eqYearAndMonth(calenderListRequestParam.year, calenderListRequestParam.month))
+			.where(eqUserIdOrEqPartnerId(calenderListRequestParam))
+			.where(eqYearAndMonth(calenderListRequestParam.year, calenderListRequestParam.month))
 			.orderBy(calendar.startDate.asc())
 			.fetch()
 	}
 
-	private fun eqUserIdOrEqPartnerId(userId: Long, partnerId: Long): BooleanExpression {
-		return calendar.user.id.eq(userId).or(calendar.user.id.eq(partnerId))
+	private fun eqUserIdOrEqPartnerId(calenderListRequestParam: CalenderListRequestParam): BooleanExpression {
+		return eqUserId(calenderListRequestParam.userId).or(eqUserId(calenderListRequestParam.partnerId))
 	}
+
+	private fun eqUserId(userId: Long?): BooleanExpression = calendar.user.id.eq(userId)
 
 	private fun eqYearAndMonth(year: Int, month: Int): BooleanExpression {
 		return calendar.startDate.year().eq(year).and(calendar.startDate.month().eq(month))

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/CalendarReader.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/CalendarReader.kt
@@ -3,15 +3,27 @@ package com.lovebird.domain.repository.reader
 import com.lovebird.common.enums.ReturnCode
 import com.lovebird.common.exception.LbException
 import com.lovebird.domain.annotation.Reader
+import com.lovebird.domain.dto.query.CalendarListResponseParam
 import com.lovebird.domain.entity.Calendar
 import com.lovebird.domain.repository.jpa.CalendarJpaRepository
+import com.lovebird.domain.repository.query.CalendarQueryRepository
 
 @Reader
 class CalendarReader(
-	private val calendarJpaRepository: CalendarJpaRepository
+	private val calendarJpaRepository: CalendarJpaRepository,
+	private val calendarQueryRepository: CalendarQueryRepository
 ) {
 
 	fun findEntityById(id: Long): Calendar {
 		return calendarJpaRepository.findById(id).orElseThrow() { throw LbException(ReturnCode.WRONG_PARAMETER) }
+	}
+
+	fun findCalendarsByDateAndUserIdAndPartnerId(
+		year: Int,
+		month: Int,
+		userId: Long,
+		partnerId: Long
+	): List<CalendarListResponseParam> {
+		return calendarQueryRepository.findCalendarsByDateAndUserIdAndPartnerId(year, month, userId, partnerId)
 	}
 }

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/CalendarReader.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/CalendarReader.kt
@@ -19,7 +19,7 @@ class CalendarReader(
 		return calendarJpaRepository.findById(id).orElseThrow() { throw LbException(ReturnCode.WRONG_PARAMETER) }
 	}
 
-	fun findCalendarsByDate(calenderListRequestParam: CalenderListRequestParam): List<CalendarListResponseParam> {
-		return calendarQueryRepository.findCalendarsByDateAndUserIdAndPartnerId(calenderListRequestParam)
+	fun findCalendarsByDate(param: CalenderListRequestParam): List<CalendarListResponseParam> {
+		return calendarQueryRepository.findCalendarsByDateAndUserIdAndPartnerId(param)
 	}
 }

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/CalendarReader.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/CalendarReader.kt
@@ -4,6 +4,7 @@ import com.lovebird.common.enums.ReturnCode
 import com.lovebird.common.exception.LbException
 import com.lovebird.domain.annotation.Reader
 import com.lovebird.domain.dto.query.CalendarListResponseParam
+import com.lovebird.domain.dto.query.CalenderListRequestParam
 import com.lovebird.domain.entity.Calendar
 import com.lovebird.domain.repository.jpa.CalendarJpaRepository
 import com.lovebird.domain.repository.query.CalendarQueryRepository
@@ -18,12 +19,7 @@ class CalendarReader(
 		return calendarJpaRepository.findById(id).orElseThrow() { throw LbException(ReturnCode.WRONG_PARAMETER) }
 	}
 
-	fun findCalendarsByDateAndUserIdAndPartnerId(
-		year: Int,
-		month: Int,
-		userId: Long,
-		partnerId: Long
-	): List<CalendarListResponseParam> {
-		return calendarQueryRepository.findCalendarsByDateAndUserIdAndPartnerId(year, month, userId, partnerId)
+	fun findCalendarsByDate(calenderListRequestParam: CalenderListRequestParam): List<CalendarListResponseParam> {
+		return calendarQueryRepository.findCalendarsByDateAndUserIdAndPartnerId(calenderListRequestParam)
 	}
 }


### PR DESCRIPTION
> ### Issue Number

#28 

> ### Description
- Spring Boot Version 변경했습니다 -> 3.1.5
- 월별 조회 시, 년도가 존재하지 않으면 기준점에 대한 문제가 발생하기에 Year에 대한 파라미터를 받도록 로직을 구성했습니다
- 기존 Java로 작성된 Spring Boot에서는 List<Calendar>에 대한 전체를 반환했지만 iOS에서 가져갈 필요가 없는 불필요한 정보라고 판단된 필드를 제거하기 위해 Projection을 활용했습니다
- CoupleEntry에 대한 Entity를 조회할 수 없을때 예외처리를 위해 임의로 구성했는데 Code Number가 정해진 것이 없어서 이 부분도 확인 부탁드립니다
- 쿼리에 필요한 Param들을 data class로 mapping하지 않고 어떤 쿼리인지 한 눈에 비즈니스 로직에서 method name과 확인할 수 있도록 구성했는데 RequestParam으로 mapping convention이 지켜져야 한다면 말씀해주세요!

```kotlin
coupleEntry?.let {
    val partner: User = it.partner
    val calendars: List<CalendarListResponseParam> = calendarReader
        .findCalendarsByDateAndUserIdAndPartnerId(year, month, user.id!!, partner.id!!)
        return CalendarListResponse.of(calendars)
}
		
if (coupleEntry != null) {
    val partner: User = coupleEntry.partner
    val calendars: List<CalendarListResponseParam> = calendarReader
        .findCalendarsByDateAndUserIdAndPartnerId(year, month, user.id!!, partner.id!!)

    return CalendarListResponse.of(calendars)
}

해당 방식의 두 차이에 대해서도 의견이 궁금하네요
```
> ### Core Code

```kotlin
fun findCalendarsByDateAndUserIdAndPartnerId(
		year: Int,
		month: Int,
		userId: Long,
		partnerId: Long
	): List<CalendarListResponseParam> {
		return queryFactory
			.select(
				Projections.constructor(
					CalendarListResponseParam::class.java,
					calendar.id,
                                        calendar.user.id,
					calendar.title,
					calendar.memo,
					calendar.startDate,
					calendar.endDate,
					calendar.startTime,
					calendar.endTime,
					calendar.color,
					calendar.alarm
				)
			)
			.from(calendar)
			.where(eqUserIdOrEqPartnerId(userId, partnerId), eqYearAndMonth(year, month))
			.orderBy(calendar.startDate.asc())
			.fetch()
	}
```

> ### etc
ps. response 형식도 Entity 그대로 List로 꼭 노출되어야 하는지 궁금하네요 불필요한 정보를 넘길 필요가 없다고 생각해서 일단 저의 논리대로 구성했습니다
```json
{
    "code": "1000",
    "message": "요청에 성공하셨습니다.",
    "data": {
        "calendars": [
            {
                "id": 1,
                "userId": 1,
                "title": "술 약속",
                "memo": null,
                "startDate": "2023-12-15",
                "endDate": null,
                "startTime": null,
                "endTime": null,
                "color": "PRIMARY",
                "alarm": "NONE"
            },
            {
                "id": 2,
                "userId": 1,
                "title": "test",
                "memo": "NONE",
                "startDate": "2023-12-15",
                "endDate": null,
                "startTime": null,
                "endTime": null,
                "color": "PRIMARY",
                "alarm": "NONE"
            },
            {
                "id": 3,
                "userId": 2,
                "title": "test",
                "memo": "NONE",
                "startDate": "2023-12-15",
                "endDate": null,
                "startTime": null,
                "endTime": null,
                "color": "PRIMARY",
                "alarm": "NONE"
            }
        ]
    }
}
```
userId와 partnerId가 요청한 year와 month에 작성한 캘린더 일정 전체 조회 Query
```text
Hibernate: 
    select
        c1_0.calendar_id,
        c1_0.user_id,
        c1_0.title,
        c1_0.memo,
        c1_0.start_date,
        c1_0.end_date,
        c1_0.start_time,
        c1_0.end_time,
        c1_0.color,
        c1_0.alarm 
    from
        calendar c1_0 
    where
        (
            c1_0.user_id=? 
            or c1_0.user_id=?
        ) 
        and (
            extract(year from c1_0.start_date)=? 
            and extract(month from c1_0.start_date)=?
        ) 
    order by
        c1_0.start_date

```