### PR TITLE
Feature | #36 | @YongsHub | Calendar 업데이트 로직 추가

### DIFF
--- a/lovebird-api/src/main/kotlin/com/lovebird/api/controller/calendar/CalendarController.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/controller/calendar/CalendarController.kt
@@ -2,6 +2,7 @@ package com.lovebird.api.controller.calendar
 
 import com.lovebird.api.dto.request.calendar.CalendarCreateRequest
 import com.lovebird.api.dto.request.calendar.CalendarListRequest
+import com.lovebird.api.dto.request.calendar.CalendarUpdateRequest
 import com.lovebird.api.dto.response.calendar.CalendarDetailResponse
 import com.lovebird.api.dto.response.calendar.CalendarListResponse
 import com.lovebird.api.service.calendar.CalendarService
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -47,5 +49,15 @@ class CalendarController(
 	): ResponseEntity<ApiResponse<Void>> {
 		calendarService.save(request, user)
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success())
+	}
+
+	@PutMapping("/{id}")
+	fun update(
+		@PathVariable id: Long,
+		@AuthorizedUser user: User,
+		@Valid @RequestBody
+		request: CalendarUpdateRequest
+	): ApiResponse<Void> {
+		return ApiResponse.success()
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/controller/calendar/CalendarController.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/controller/calendar/CalendarController.kt
@@ -58,6 +58,7 @@ class CalendarController(
 		@Valid @RequestBody
 		request: CalendarUpdateRequest
 	): ApiResponse<Void> {
+		calendarService.update(id, request, user)
 		return ApiResponse.success()
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/controller/calendar/CalendarController.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/controller/calendar/CalendarController.kt
@@ -58,7 +58,7 @@ class CalendarController(
 		@Valid @RequestBody
 		request: CalendarUpdateRequest
 	): ApiResponse<Void> {
-		calendarService.update(id, request, user)
+		calendarService.update(request.toParam(id, user))
 		return ApiResponse.success()
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/param/calendar/CalendarUpdateParam.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/param/calendar/CalendarUpdateParam.kt
@@ -1,0 +1,10 @@
+package com.lovebird.api.dto.param.calendar
+
+import com.lovebird.api.dto.request.calendar.CalendarUpdateRequest
+import com.lovebird.domain.entity.User
+
+data class CalendarUpdateParam(
+	val calendarId: Long,
+	val user: User,
+	val request: CalendarUpdateRequest
+)

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarCreateRequest.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarCreateRequest.kt
@@ -23,6 +23,16 @@ data class CalendarCreateRequest(
 	val endTime: LocalTime?
 ) {
 	fun toEntity(user: User): Calendar {
-		return Calendar(title, memo, startDate, endDate ?: startDate, startTime, endTime, color, alarm, user)
+		return Calendar(
+			title = title,
+			memo = memo,
+			startDate = startDate,
+			endDate = endDate ?: startDate,
+			startTime = startTime,
+			endTime = endTime,
+			color = color,
+			alarm = alarm ?: Alarm.NONE,
+			user = user
+		)
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarUpdateRequest.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarUpdateRequest.kt
@@ -11,8 +11,8 @@ import java.time.LocalTime
 data class CalendarUpdateRequest(
 	val title: String,
 	val memo: String?,
-	val color: Color?,
-	val alarm: Alarm?,
+	val color: Color,
+	val alarm: Alarm,
 	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
 	val startDate: LocalDate,
 	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarUpdateRequest.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarUpdateRequest.kt
@@ -28,6 +28,15 @@ data class CalendarUpdateRequest(
 	}
 
 	fun toEntity(user: User): Calendar {
-		return Calendar(title, memo, startDate, endDate, startTime, endTime, color, alarm, user)
+		return Calendar(
+			title = title,
+			memo = memo,
+			startDate = startDate,
+			endDate = endDate,
+			startTime = startTime,
+			endTime = endTime,
+			color = color,
+			alarm = alarm,
+			user = user)
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarUpdateRequest.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarUpdateRequest.kt
@@ -1,5 +1,6 @@
 package com.lovebird.api.dto.request.calendar
 
+import com.lovebird.api.dto.param.calendar.CalendarUpdateParam
 import com.lovebird.common.enums.Alarm
 import com.lovebird.common.enums.Color
 import com.lovebird.domain.entity.Calendar
@@ -22,6 +23,10 @@ data class CalendarUpdateRequest(
 	@DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
 	val endTime: LocalTime?
 ) {
+	fun toParam(calendarId: Long, user: User): CalendarUpdateParam {
+		return CalendarUpdateParam(calendarId, user, this)
+	}
+
 	fun toEntity(user: User): Calendar {
 		return Calendar(title, memo, startDate, endDate, startTime, endTime, color, alarm, user)
 	}

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarUpdateRequest.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarUpdateRequest.kt
@@ -1,0 +1,3 @@
+package com.lovebird.api.dto.request.calendar
+
+data class CalendarUpdateRequest()

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarUpdateRequest.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarUpdateRequest.kt
@@ -1,3 +1,28 @@
 package com.lovebird.api.dto.request.calendar
 
-data class CalendarUpdateRequest()
+import com.lovebird.common.enums.Alarm
+import com.lovebird.common.enums.Color
+import com.lovebird.domain.entity.Calendar
+import com.lovebird.domain.entity.User
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class CalendarUpdateRequest(
+	val title: String,
+	val memo: String?,
+	val color: Color?,
+	val alarm: Alarm?,
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+	val startDate: LocalDate,
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+	val endDate: LocalDate,
+	@DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
+	val startTime: LocalTime?,
+	@DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
+	val endTime: LocalTime?
+) {
+	fun toEntity(user: User): Calendar {
+		return Calendar(title, memo, startDate, endDate, startTime, endTime, color, alarm, user)
+	}
+}

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarUpdateRequest.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/request/calendar/CalendarUpdateRequest.kt
@@ -37,6 +37,7 @@ data class CalendarUpdateRequest(
 			endTime = endTime,
 			color = color,
 			alarm = alarm,
-			user = user)
+			user = user
+		)
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
@@ -1,6 +1,7 @@
 package com.lovebird.api.service.calendar
 
 import com.lovebird.api.dto.param.calendar.CalendarListParam
+import com.lovebird.api.dto.param.calendar.CalendarUpdateParam
 import com.lovebird.api.dto.request.calendar.CalendarCreateRequest
 import com.lovebird.api.dto.request.calendar.CalendarUpdateRequest
 import com.lovebird.api.dto.response.calendar.CalendarDetailResponse
@@ -67,7 +68,10 @@ class CalendarService(
 	}
 
 	@Transactional
-	fun update(calendarId: Long, request: CalendarUpdateRequest, user: User) {
+	fun update(calendarUpdateParam: CalendarUpdateParam) {
+		val calendarId: Long = calendarUpdateParam.calendarId
+		val user: User = calendarUpdateParam.user
+		val request: CalendarUpdateRequest = calendarUpdateParam.request
 		val calendar: Calendar = calendarReader.findEntityById(calendarId)
 
 		calendar.updateCalendar(request.toEntity(user))

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
@@ -68,15 +68,15 @@ class CalendarService(
 	}
 
 	@Transactional
-	fun update(calendarId:Long, request: CalendarUpdateRequest, user: User) {
+	fun update(calendarId: Long, request: CalendarUpdateRequest, user: User) {
 		val calendar: Calendar = calendarReader.findEntityById(calendarId)
 
 		calendar.updateCalendar(request.toEntity(user))
 
 		val newEventAt: LocalDateTime = DateUtils.toLocalDateTime(request.startDate, request.startTime)
-		val calendarEvents: List<CalendarEvent> =  calendarEventReader.findCalendarEventsByCalendar(calendar)
+		val calendarEvents: List<CalendarEvent> = calendarEventReader.findCalendarEventsByCalendar(calendar)
 
-		calendarEvents.forEach {calendarEvent ->
+		calendarEvents.forEach { calendarEvent ->
 			calendarEvent.updateCalendarEvent(newEventAt, request.alarm ?: Alarm.NONE)
 		}
 	}

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
@@ -5,7 +5,6 @@ import com.lovebird.api.dto.request.calendar.CalendarCreateRequest
 import com.lovebird.api.dto.request.calendar.CalendarUpdateRequest
 import com.lovebird.api.dto.response.calendar.CalendarDetailResponse
 import com.lovebird.api.dto.response.calendar.CalendarListResponse
-import com.lovebird.common.enums.Alarm
 import com.lovebird.common.util.DateUtils
 import com.lovebird.domain.dto.query.CalendarEventRequestParam
 import com.lovebird.domain.dto.query.CalendarListResponseParam
@@ -77,7 +76,7 @@ class CalendarService(
 		val calendarEvents: List<CalendarEvent> = calendarEventReader.findCalendarEventsByCalendar(calendar)
 
 		calendarEvents.forEach { calendarEvent ->
-			calendarEvent.updateCalendarEvent(newEventAt, request.alarm ?: Alarm.NONE)
+			calendarEvent.updateCalendarEvent(newEventAt, request.alarm)
 		}
 	}
 }

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/CalendarEventRequestParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/CalendarEventRequestParam.kt
@@ -11,6 +11,6 @@ data class CalendarEventRequestParam(
 	val eventAt: LocalDateTime
 ) {
 	fun toEntity(): CalendarEvent {
-		return CalendarEvent(calendar, user, eventAt, calendar.alarm!!)
+		return CalendarEvent(calendar, user, eventAt.minusMinutes(calendar.alarm!!.value), calendar.alarm!!)
 	}
 }

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/Calendar.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/Calendar.kt
@@ -16,12 +16,14 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.ColumnDefault
+import org.hibernate.annotations.DynamicInsert
 import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDate
 import java.time.LocalTime
 
 @Entity
 @Table(name = "calendar")
+@DynamicInsert
 class Calendar(
 	title: String,
 	memo: String?,
@@ -70,7 +72,7 @@ class Calendar(
 	@Enumerated(value = EnumType.STRING)
 	var color: Color? = color
 
-	@Column(name = "alarm")
+	@Column(name = "alarm", nullable = false)
 	@ColumnDefault("'NONE'")
 	@Enumerated(value = EnumType.STRING)
 	var alarm: Alarm? = alarm
@@ -78,4 +80,15 @@ class Calendar(
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "user_id", referencedColumnName = "user_id", nullable = false)
 	val user: User = user
+
+	fun updateCalendar(calendar: Calendar) {
+		this.title = calendar.title
+		this.memo = calendar.memo
+		this.startDate = calendar.startDate
+		this.endDate = calendar.endDate
+		this.startTime = calendar.startTime
+		this.endTime = calendar.endTime
+		this.color = calendar.color
+		this.alarm = calendar.alarm
+	}
 }

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/Calendar.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/Calendar.kt
@@ -16,14 +16,12 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.ColumnDefault
-import org.hibernate.annotations.DynamicInsert
 import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDate
 import java.time.LocalTime
 
 @Entity
 @Table(name = "calendar")
-@DynamicInsert
 class Calendar(
 	title: String,
 	memo: String?,

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/CalendarEvent.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/CalendarEvent.kt
@@ -40,15 +40,25 @@ class CalendarEvent(
 	val calendar: Calendar = calendar
 
 	@Column(name = "send_flag")
-	val sendFlag: Boolean = false
+	var sendFlag: Boolean = false
 
 	@Column(name = "event_at")
-	val eventAt: LocalDateTime = eventAt
+	var eventAt: LocalDateTime = eventAt
 
 	@Column(name = "alarm")
 	@Enumerated(value = EnumType.STRING)
-	val alarm: Alarm = alarm
+	var alarm: Alarm = alarm
 
 	@Column(name = "result")
 	val result: String = "알림 발송 전"
+
+	fun updateCalendarEvent(newEventAt: LocalDateTime, alarm: Alarm) {
+		if (!eventAt.isEqual(newEventAt)) {
+			this.eventAt = newEventAt.minusMinutes(alarm.value)
+			this.alarm = alarm
+			if (this.eventAt.isAfter(LocalDateTime.now())) {
+				this.sendFlag = false
+			}
+		}
+	}
 }

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/jpa/CalendarEventJpaRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/jpa/CalendarEventJpaRepository.kt
@@ -1,6 +1,10 @@
 package com.lovebird.domain.repository.jpa
 
+import com.lovebird.domain.entity.Calendar
 import com.lovebird.domain.entity.CalendarEvent
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CalendarEventJpaRepository : JpaRepository<CalendarEvent, Long>
+interface CalendarEventJpaRepository : JpaRepository<CalendarEvent, Long> {
+
+	fun findAllByCalendar(calendar: Calendar): List<CalendarEvent>
+}

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/CalendarEventReader.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/reader/CalendarEventReader.kt
@@ -1,0 +1,15 @@
+package com.lovebird.domain.repository.reader
+
+import com.lovebird.domain.annotation.Reader
+import com.lovebird.domain.entity.Calendar
+import com.lovebird.domain.entity.CalendarEvent
+import com.lovebird.domain.repository.jpa.CalendarEventJpaRepository
+
+@Reader
+class CalendarEventReader(
+	private val calendarEventJpaRepository: CalendarEventJpaRepository
+) {
+	fun findCalendarEventsByCalendar(calendar: Calendar): List<CalendarEvent> {
+		return calendarEventJpaRepository.findAllByCalendar(calendar)
+	}
+}


### PR DESCRIPTION
> ### Issue Number

#36 

> ### Description

- Calendar Update 로직을 추가했습니다
- Calendar Update 시, 알람 관련 변경 로직도 포함했습니다

기존 Java 코드에서 `HTTP Method PUT` 을 활용하기 때문에 nullable 허용 여부를 줄였습니다 즉, null일 필요가 없는 값에 대해서는 엄격한 제한을 두었습니다.

> ### Core Code

```kotlin
@Transactional
fun update(calendarUpdateParam: CalendarUpdateParam) {
    val calendarId: Long = calendarUpdateParam.calendarId
    val user: User = calendarUpdateParam.user
    val request: CalendarUpdateRequest = calendarUpdateParam.request
    val calendar: Calendar = calendarReader.findEntityById(calendarId)

    calendar.updateCalendar(request.toEntity(user))

    val newEventAt: LocalDateTime = DateUtils.toLocalDateTime(request.startDate, request.startTime)
    val calendarEvents: List<CalendarEvent> = calendarEventReader.findCalendarEventsByCalendar(calendar)

    calendarEvents.forEach { calendarEvent ->
        calendarEvent.updateCalendarEvent(newEventAt, request.alarm)
        }
    }
```
* List형식으로 존재하는 이유 -> CalendarEvent가 partner 존재에 따라 1개 또는 2개로 생성됐기 때문입니다
* event의 localDateTime은 newEventAt과 비교 로직이 존재합니다
> ### etc
기존의 CalendarEvent에서 다루는 로직이 partnerId, calendarId, userId 등 `객체지향적인 설계`가 아니라고 판단해서 JPA의 장점을 가져갈 수 있도록 Entity Column을 변경했습니다
기존의 Java 코드의 비즈니스 로직이랑 다르게 구성했는데 의견 주시면 감사합니다
