### PR TITLE
Feature | #42 | @YongsHub | Calendar 일정에 따른 스케쥴링 로직 추가

### DIFF
--- a/lovebird-api/src/main/kotlin/com/lovebird/api/config/ScheduleConfig.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/config/ScheduleConfig.kt
@@ -1,0 +1,24 @@
+package com.lovebird.api.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.task.TaskExecutor
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+
+
+@Configuration
+@EnableScheduling
+class ScheduleConfig {
+
+	@Bean
+	fun taskExecutor(): TaskExecutor {
+		val threadPoolTaskExecutor = ThreadPoolTaskExecutor()
+
+		threadPoolTaskExecutor.corePoolSize = 5
+		threadPoolTaskExecutor.maxPoolSize = 10
+		threadPoolTaskExecutor.queueCapacity = 25
+
+		return threadPoolTaskExecutor
+	}
+}

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/config/ScheduleConfig.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/config/ScheduleConfig.kt
@@ -6,7 +6,6 @@ import org.springframework.core.task.TaskExecutor
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 
-
 @Configuration
 @EnableScheduling
 class ScheduleConfig {

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
@@ -30,8 +30,8 @@ class CalendarService(
 	private val coupleEntryReader: CoupleEntryReader,
 	private val calendarWriter: CalendarWriter,
 	private val calendarEventWriter: CalendarEventWriter,
-	private val calendarEventReader: CalendarEventReader,
-	//private val schedulerService: SchedulerService
+	private val calendarEventReader: CalendarEventReader
+	// private val schedulerService: SchedulerService
 ) {
 
 	@Transactional(readOnly = true)
@@ -69,8 +69,8 @@ class CalendarService(
 			calendarEventWriter.save(CalendarEventRequestParam(calendar, coupleEntry.partner, eventAt))
 		}
 
-		//FCM ALARM 발생 시키는 로직
-		//schedulerService.registryCalendarAlarm(calendar)
+		// FCM ALARM 발생 시키는 로직
+		// schedulerService.registryCalendarAlarm(calendar)
 	}
 
 	@Transactional
@@ -90,8 +90,8 @@ class CalendarService(
 			calendarEvent.updateCalendarEvent(newEventAt, request.alarm)
 		}
 
-		//FCM ALARM 발생 시키는 로직
-		//schedulerService.registryCalendarAlarm(calendar)
+		// FCM ALARM 발생 시키는 로직
+		// schedulerService.registryCalendarAlarm(calendar)
 	}
 
 	@Transactional

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/CalendarService.kt
@@ -30,7 +30,8 @@ class CalendarService(
 	private val coupleEntryReader: CoupleEntryReader,
 	private val calendarWriter: CalendarWriter,
 	private val calendarEventWriter: CalendarEventWriter,
-	private val calendarEventReader: CalendarEventReader
+	private val calendarEventReader: CalendarEventReader,
+	//private val schedulerService: SchedulerService
 ) {
 
 	@Transactional(readOnly = true)
@@ -67,6 +68,9 @@ class CalendarService(
 		if (coupleEntry != null) {
 			calendarEventWriter.save(CalendarEventRequestParam(calendar, coupleEntry.partner, eventAt))
 		}
+
+		//FCM ALARM 발생 시키는 로직
+		//schedulerService.registryCalendarAlarm(calendar)
 	}
 
 	@Transactional
@@ -85,6 +89,9 @@ class CalendarService(
 		calendarEvents.forEach { calendarEvent ->
 			calendarEvent.updateCalendarEvent(newEventAt, request.alarm)
 		}
+
+		//FCM ALARM 발생 시키는 로직
+		//schedulerService.registryCalendarAlarm(calendar)
 	}
 
 	@Transactional

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/SchedulerService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/SchedulerService.kt
@@ -1,0 +1,69 @@
+package com.lovebird.api.service.calendar
+
+import com.lovebird.common.enums.AlarmResponse
+import com.lovebird.domain.entity.Calendar
+import com.lovebird.domain.entity.CalendarEvent
+import com.lovebird.domain.repository.reader.CalendarEventReader
+import com.lovebird.fcm.dto.param.FcmNotificationParam
+import com.lovebird.fcm.service.FcmService
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@Service
+class SchedulerService(
+	private val taskScheduler: TaskScheduler,
+	private val fcmService: FcmService,
+	private val calendarEventReader: CalendarEventReader
+) {
+	companion object {
+		const val ALARM_TITLE = "[LoveBird] 예정된 일정이 있어요!"
+	}
+
+	fun registryCalendarAlarm(calendar: Calendar) {
+		val calendarEvents: List<CalendarEvent> = calendarEventReader.findCalendarEventsByCalendar(calendar)
+
+		if (calendarEvents.isNotEmpty()) {
+			val localDateTime: LocalDateTime = calendarEvents.first().eventAt
+
+			taskScheduler.schedule(setTask(calendar), localDateTime.toInstant(ZoneOffset.UTC))
+		}
+	}
+
+	@Transactional
+	fun setTask(calendar: Calendar): Runnable {
+		return Runnable {
+			val calendarEvents: List<CalendarEvent> = calendarEventReader.findCalendarEventsByCalendar(calendar)
+
+			if (calendarEvents.isNotEmpty()) {
+				val localDateTime: LocalDateTime = LocalDateTime.now()
+
+				// Instant 시간에 실행 될 시, 시간 검증
+				if (isSameTime(calendarEvents.first(), localDateTime)) {
+					val deviceTokens = calendarEvents.stream().map { it.user.deviceToken!! }.toList()
+
+					fcmService.sendNotificationAsync(FcmNotificationParam(
+						deviceTokens = deviceTokens,
+						title = ALARM_TITLE,
+						body = AlarmResponse.ALARM_SEND_SUCCESS.message,
+						data = mutableListOf()
+					))
+
+					// 플래그 설정
+					calendarEvents.forEach {
+						it.setFlag()
+					}
+				}
+			}
+		}
+	}
+
+	private fun isSameTime(calendarEvent: CalendarEvent, localDateTime: LocalDateTime): Boolean {
+		return calendarEvent.eventAt.year == localDateTime.year &&
+			calendarEvent.eventAt.month == localDateTime.month &&
+			calendarEvent.eventAt.dayOfMonth == localDateTime.dayOfMonth &&
+			calendarEvent.eventAt.minute == localDateTime.minute
+	}
+}

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/SchedulerService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/calendar/SchedulerService.kt
@@ -44,12 +44,14 @@ class SchedulerService(
 				if (isSameTime(calendarEvents.first(), localDateTime)) {
 					val deviceTokens = calendarEvents.stream().map { it.user.deviceToken!! }.toList()
 
-					fcmService.sendNotificationAsync(FcmNotificationParam(
-						deviceTokens = deviceTokens,
-						title = ALARM_TITLE,
-						body = AlarmResponse.ALARM_SEND_SUCCESS.message,
-						data = mutableListOf()
-					))
+					fcmService.sendNotificationAsync(
+						FcmNotificationParam(
+							deviceTokens = deviceTokens,
+							title = ALARM_TITLE,
+							body = AlarmResponse.ALARM_SEND_SUCCESS.message,
+							data = mutableListOf()
+						)
+					)
 
 					// 플래그 설정
 					calendarEvents.forEach {

--- a/lovebird-common/src/main/kotlin/com/lovebird/common/enums/AlarmResponse.kt
+++ b/lovebird-common/src/main/kotlin/com/lovebird/common/enums/AlarmResponse.kt
@@ -1,0 +1,7 @@
+package com.lovebird.common.enums
+
+enum class AlarmResponse(
+	val message: String
+) {
+	ALARM_SEND_SUCCESS("연인과의 일정을 잊으신건 아니죠?")
+}

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/CalendarEvent.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/entity/CalendarEvent.kt
@@ -70,4 +70,8 @@ class CalendarEvent(
 			}
 		}
 	}
+
+	fun setFlag() {
+		this.sendFlag = true
+	}
 }


### PR DESCRIPTION
> ### Issue Number

#42

> ### Description
- 매초 스케쥴링을 통해 CalendarEvent에 대해 Disk I/O 작업인 Full Scan하는 로직이 과연 좋은 방법일까? 에 대해 고민했습니다
- Spring Docs에서 설명되어 있는 TaskScheduleExecutor를 활용하면 조금 더 우아하게 로직을 구성할 수 있다는 판단을 했는데 함께 적합성을 판단해보면 좋을 것 같아요

Docs에서 제공하는 핵심 설명입니다
```java
public interface TaskScheduler {

	Clock getClock();

	ScheduledFuture schedule(Runnable task, Trigger trigger);

	ScheduledFuture schedule(Runnable task, Instant startTime);

	ScheduledFuture scheduleAtFixedRate(Runnable task, Instant startTime, Duration period);

	ScheduledFuture scheduleAtFixedRate(Runnable task, Duration period);

	ScheduledFuture scheduleWithFixedDelay(Runnable task, Instant startTime, Duration delay);

	ScheduledFuture scheduleWithFixedDelay(Runnable task, Duration delay);
```

추상화된 서비스를 통해서 원하는 로직들을 구현할 수 있습니다.

따라서 Instant startTime에 대해 -> CalendarEvent에 대한 eventAt을 통해 설정했습니다
-> 해당 스케쥴링을 트리거 시키는 로직에 대한 업데이트에 대해 찾아보고 있는데 잘 찾지 못하고 있습니다 ,,ㅋㅋㅎ
따라서, 검증 로직으로 시간이 일치할 경우 FCM send로직이 돌게금 구성했습니다.
> ### Core Code

```kotlin
@Transactional
fun setTask(calendar: Calendar): Runnable {
	return Runnable {
		val calendarEvents: List<CalendarEvent> = calendarEventReader.findCalendarEventsByCalendar(calendar)

		if (calendarEvents.isNotEmpty()) {
			val localDateTime: LocalDateTime = LocalDateTime.now()

			// Instant 시간에 실행 될 시, 시간 검증
			if (isSameTime(calendarEvents.first(), localDateTime)) {
				val deviceTokens = calendarEvents.stream().map { it.user.deviceToken!! }.toList()

				fcmService.sendNotificationAsync(
					FcmNotificationParam(
						deviceTokens = deviceTokens,
						title = SchedulerService.ALARM_TITLE,
						body = AlarmResponse.ALARM_SEND_SUCCESS.message,
						data = mutableListOf()
					)
				)

				// 플래그 설정
				calendarEvents.forEach {
					it.setFlag()
				}
			}
		}
	}
}
```
> ### etc
