### PR TITLE
Feature | #73 | @lcomment | access token 재발급 기능 구현

### DIFF
--- a/lovebird-api/build.gradle.kts
+++ b/lovebird-api/build.gradle.kts
@@ -134,7 +134,7 @@ val testCoverage by tasks.registering {
 
 tasks.test {
 	extensions.configure(JacocoTaskExtension::class) {
-		destinationFile = file("$buildDir/jacoco/jacoco.exec")
+		setDestinationFile(layout.buildDirectory.file("jacoco/jacoco.exec").get().asFile)
 	}
 	outputs.dir(snippetsDir)
 	finalizedBy("jacocoTestReport")

--- a/lovebird-api/src/docs/asciidoc/auth.adoc
+++ b/lovebird-api/src/docs/asciidoc/auth.adoc
@@ -39,3 +39,9 @@ operation::1000-sign-in-naver[snippets='http-request,http-response,request-field
 ==== `Fail` (가입하지 않은 회원)
 
 operation::1202-sign-in-naver[snippets='http-request,http-response,request-fields,response-fields']
+
+=== Access Token 재발급
+
+==== `Success`
+
+operation::1000-recreate-access-token[snippets='http-request,http-response,request-headers,response-fields']

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/annotation/RefreshToken.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/annotation/RefreshToken.kt
@@ -1,0 +1,5 @@
+package com.lovebird.api.annotation
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RefreshToken

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/common/resolver/RefreshTokenResolver.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/common/resolver/RefreshTokenResolver.kt
@@ -1,0 +1,26 @@
+package com.lovebird.api.common.resolver
+
+import com.lovebird.api.annotation.RefreshToken
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class RefreshTokenResolver : HandlerMethodArgumentResolver {
+
+	override fun supportsParameter(parameter: MethodParameter): Boolean {
+		return parameter.hasParameterAnnotation(RefreshToken::class.java) && String::class.java.isAssignableFrom(parameter.parameterType)
+	}
+
+	override fun resolveArgument(
+		parameter: MethodParameter,
+		mavContainer: ModelAndViewContainer?,
+		webRequest: NativeWebRequest,
+		binderFactory: WebDataBinderFactory?
+	): String? {
+		return webRequest.getHeader("Refresh")
+	}
+}

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/config/WebMvcConfig.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/config/WebMvcConfig.kt
@@ -1,6 +1,7 @@
 package com.lovebird.api.config
 
 import com.lovebird.api.common.resolver.AuthorizedUserResolver
+import com.lovebird.api.common.resolver.RefreshTokenResolver
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
@@ -10,5 +11,6 @@ class WebMvcConfig : WebMvcConfigurer {
 
 	override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
 		resolvers.add(AuthorizedUserResolver())
+		resolvers.add(RefreshTokenResolver())
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/controller/user/AuthController.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/controller/user/AuthController.kt
@@ -1,7 +1,9 @@
 package com.lovebird.api.controller.user
 
+import com.lovebird.api.annotation.RefreshToken
 import com.lovebird.api.dto.request.user.SignInRequest
 import com.lovebird.api.dto.request.user.SignUpRequest
+import com.lovebird.api.dto.response.user.AccessTokenResponse
 import com.lovebird.api.dto.response.user.SignInResponse
 import com.lovebird.api.dto.response.user.SignUpResponse
 import com.lovebird.api.service.user.AuthService
@@ -39,5 +41,10 @@ class AuthController(
 	@PostMapping("/sign-in/naver")
 	fun signIn(@RequestBody request: SignInRequest.NaverUserRequest): ApiResponse<SignInResponse> {
 		return ApiResponse.success(authService.signInUsingNaver(request.toParam()))
+	}
+
+	@PostMapping("/access-token")
+	fun regenerateAccessToken(@RefreshToken refreshToken: String): ApiResponse<AccessTokenResponse> {
+		return ApiResponse.success(authService.recreateAccessToken(refreshToken))
 	}
 }

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/dto/response/user/AccessTokenResponse.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/dto/response/user/AccessTokenResponse.kt
@@ -1,0 +1,3 @@
+package com.lovebird.api.dto.response.user
+
+data class AccessTokenResponse(val accessToken: String)

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/provider/JwtProvider.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/provider/JwtProvider.kt
@@ -1,8 +1,8 @@
 package com.lovebird.api.provider
 
+import com.lovebird.api.dto.response.user.AccessTokenResponse
 import com.lovebird.api.vo.JwtToken
 import com.lovebird.api.vo.PrincipalUser
-import com.lovebird.api.vo.RefreshToken
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
@@ -30,11 +30,11 @@ class JwtProvider(
 		return JwtToken(accessToken, refreshToken, grantType)
 	}
 
-	fun generateRefreshToken(principalUser: PrincipalUser): RefreshToken {
+	fun generateAccessToken(principalUser: PrincipalUser): AccessTokenResponse {
 		val claims = getClaims(principalUser)
-		val refreshToken = generateRefreshToken(principalUser, claims)
+		val accessToken = generateAccessToken(principalUser, claims)
 
-		return RefreshToken(refreshToken, grantType)
+		return AccessTokenResponse(accessToken)
 	}
 
 	private fun getClaims(principalUser: PrincipalUser): Claims {

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/validator/JwtValidator.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/validator/JwtValidator.kt
@@ -29,6 +29,13 @@ class JwtValidator(
 		return UsernamePasswordAuthenticationToken(principalUser, "", principalUser.authorities)
 	}
 
+	fun getPrincipalUser(token: String): PrincipalUser {
+		val claims = getTokenClaims(token)
+		val user: User = userReader.findEntityById(claims.get("id", String::class.java).toLong())
+
+		return PrincipalUser.of(user)
+	}
+
 	@Suppress("UNCHECKED_CAST")
 	fun parseHeaders(token: String): Map<String, String> {
 		val header = token.split(".")[0]

--- a/lovebird-api/src/main/resources/static/docs/index.html
+++ b/lovebird-api/src/main/resources/static/docs/index.html
@@ -464,6 +464,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_naver_회원가입">5.2. Naver 회원가입</a></li>
 <li><a href="#_oidc_로그인_apple_google_kakao">5.3. oidc 로그인 (apple, google, kakao)</a></li>
 <li><a href="#_naver_로그인">5.4. Naver 로그인</a></li>
+<li><a href="#_access_token_재발급">5.5. Access Token 재발급</a></li>
 </ul>
 </li>
 <li><a href="#_profile">6. Profile</a>
@@ -490,12 +491,13 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </li>
 <li><a href="#_diary">9. Diary</a>
 <ul class="sectlevel2">
-<li><a href="#_success_13">9.1. <code>Success</code></a></li>
+<li><a href="#_success_14">9.1. <code>Success</code></a></li>
 <li><a href="#_데이트_날짜_기준_다이어리_조회">9.2. 데이트 날짜 기준 다이어리 조회</a></li>
 <li><a href="#_커서_기반_다이어리_리스트_조회">9.3. 커서 기반 다이어리 리스트 조회</a></li>
 <li><a href="#_다이어리_상세_조회">9.4. 다이어리 상세 조회</a></li>
 <li><a href="#_다이어리_생성">9.5. 다이어리 생성</a></li>
 <li><a href="#_다이어리_수정">9.6. 다이어리 수정</a></li>
+<li><a href="#_다이어리_삭제">9.7. 다이어리 삭제</a></li>
 </ul>
 </li>
 </ul>
@@ -1978,22 +1980,18 @@ Content-Length: 93
 </div>
 </div>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_profile"><a class="link" href="#_profile">6. Profile</a></h2>
-<div class="sectionbody">
 <div class="sect2">
-<h3 id="_조회"><a class="link" href="#_조회">6.1. 조회</a></h3>
+<h3 id="_access_token_재발급"><a class="link" href="#_access_token_재발급">5.5. Access Token 재발급</a></h3>
 <div class="sect3">
-<h4 id="_success_5"><a class="link" href="#_success_5">6.1.1. <code>Success</code></a></h4>
+<h4 id="_success_5"><a class="link" href="#_success_5">5.5.1. <code>Success</code></a></h4>
 <div class="sect4">
 <h5 id="_success_5_http_request"><a class="link" href="#_success_5_http_request">HTTP request</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/profile HTTP/1.1
-Authorization: Bearer access-token
-Host: localhost:8080</code></pre>
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/access-token HTTP/1.1
+Refresh: refresh-token
+Host: localhost:8080
+Content-Type: application/x-www-form-urlencoded</code></pre>
 </div>
 </div>
 </div>
@@ -2003,26 +2001,13 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 484
+Content-Length: 124
 
 {
   "code" : "1000",
   "message" : "요청에 성공하셨습니다.",
   "data" : {
-    "userId" : 1,
-    "partnerId" : 2,
-    "email" : "",
-    "nickname" : "test",
-    "partnerNickname" : "test2",
-    "firstDate" : "2024-01-01",
-    "birthday" : "2024-02-02",
-    "dayCount" : 48,
-    "nextAnniversary" : {
-      "kind" : "BIRTHDAY",
-      "anniversaryDate" : "2024-02-02"
-    },
-    "profileImageUrl" : "profile image url",
-    "partnerImageUrl" : "partner profile image url"
+    "accessToken" : "access-token"
   }
 }</code></pre>
 </div>
@@ -2043,6 +2028,118 @@ Content-Length: 484
 </thead>
 <tbody>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Refresh</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">리프레시 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_success_5_response_fields"><a class="link" href="#_success_5_response_fields">Response fields</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.accessToken</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_profile"><a class="link" href="#_profile">6. Profile</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_조회"><a class="link" href="#_조회">6.1. 조회</a></h3>
+<div class="sect3">
+<h4 id="_success_6"><a class="link" href="#_success_6">6.1.1. <code>Success</code></a></h4>
+<div class="sect4">
+<h5 id="_success_6_http_request"><a class="link" href="#_success_6_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/profile HTTP/1.1
+Authorization: Bearer access-token
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_success_6_http_response"><a class="link" href="#_success_6_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 484
+
+{
+  "code" : "1000",
+  "message" : "요청에 성공하셨습니다.",
+  "data" : {
+    "userId" : 1,
+    "partnerId" : 2,
+    "email" : "",
+    "nickname" : "test",
+    "partnerNickname" : "test2",
+    "firstDate" : "2024-01-01",
+    "birthday" : "2024-02-13",
+    "dayCount" : 48,
+    "nextAnniversary" : {
+      "kind" : "BIRTHDAY",
+      "anniversaryDate" : "2024-02-13"
+    },
+    "profileImageUrl" : "profile image url",
+    "partnerImageUrl" : "partner profile image url"
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_success_6_request_headers"><a class="link" href="#_success_6_request_headers">Request headers</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
 </tr>
@@ -2050,7 +2147,7 @@ Content-Length: 484
 </table>
 </div>
 <div class="sect4">
-<h5 id="_success_5_response_fields"><a class="link" href="#_success_5_response_fields">Response fields</a></h5>
+<h5 id="_success_6_response_fields"><a class="link" href="#_success_6_response_fields">Response fields</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -2166,8 +2263,8 @@ Host: localhost:8080
   "imageUrl" : "test-image-url",
   "email" : "test-email",
   "nickname" : "test-nickname",
-  "birthday" : "2024-02-02",
-  "firstDate" : "2024-02-02",
+  "birthday" : "2024-02-13",
+  "firstDate" : "2024-02-13",
   "gender" : "UNKNOWN"
 }</code></pre>
 </div>
@@ -2302,9 +2399,9 @@ Content-Length: 88
 <div class="sect2">
 <h3 id="_연동_코드_발급"><a class="link" href="#_연동_코드_발급">7.1. 연동 코드 발급</a></h3>
 <div class="sect3">
-<h4 id="_success_6"><a class="link" href="#_success_6">7.1.1. <code>Success</code></a></h4>
+<h4 id="_success_7"><a class="link" href="#_success_7">7.1.1. <code>Success</code></a></h4>
 <div class="sect4">
-<h5 id="_success_6_http_request"><a class="link" href="#_success_6_http_request">HTTP request</a></h5>
+<h5 id="_success_7_http_request"><a class="link" href="#_success_7_http_request">HTTP request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/couple/code HTTP/1.1
@@ -2315,7 +2412,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_success_6_http_response"><a class="link" href="#_success_6_http_response">HTTP response</a></h5>
+<h5 id="_success_7_http_response"><a class="link" href="#_success_7_http_response">HTTP response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2334,7 +2431,7 @@ Content-Length: 149
 </div>
 </div>
 <div class="sect4">
-<h5 id="_success_6_request_headers"><a class="link" href="#_success_6_request_headers">Request headers</a></h5>
+<h5 id="_success_7_request_headers"><a class="link" href="#_success_7_request_headers">Request headers</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -2355,7 +2452,7 @@ Content-Length: 149
 </table>
 </div>
 <div class="sect4">
-<h5 id="_success_6_response_fields"><a class="link" href="#_success_6_response_fields">Response fields</a></h5>
+<h5 id="_success_7_response_fields"><a class="link" href="#_success_7_response_fields">Response fields</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -2807,9 +2904,9 @@ Content-Length: 114
 <div class="sect2">
 <h3 id="_연동_여부_확인"><a class="link" href="#_연동_여부_확인">7.3. 연동 여부 확인</a></h3>
 <div class="sect3">
-<h4 id="_success_7"><a class="link" href="#_success_7">7.3.1. <code>Success</code></a></h4>
+<h4 id="_success_8"><a class="link" href="#_success_8">7.3.1. <code>Success</code></a></h4>
 <div class="sect4">
-<h5 id="_success_7_http_request"><a class="link" href="#_success_7_http_request">HTTP request</a></h5>
+<h5 id="_success_8_http_request"><a class="link" href="#_success_8_http_request">HTTP request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/couple/check HTTP/1.1
@@ -2819,7 +2916,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_success_7_http_response"><a class="link" href="#_success_7_http_response">HTTP response</a></h5>
+<h5 id="_success_8_http_response"><a class="link" href="#_success_8_http_response">HTTP response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2837,7 +2934,7 @@ Content-Length: 113
 </div>
 </div>
 <div class="sect4">
-<h5 id="_success_7_request_headers"><a class="link" href="#_success_7_request_headers">Request headers</a></h5>
+<h5 id="_success_8_request_headers"><a class="link" href="#_success_8_request_headers">Request headers</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -2858,7 +2955,7 @@ Content-Length: 113
 </table>
 </div>
 <div class="sect4">
-<h5 id="_success_7_response_fields"><a class="link" href="#_success_7_response_fields">Response fields</a></h5>
+<h5 id="_success_8_response_fields"><a class="link" href="#_success_8_response_fields">Response fields</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -2906,9 +3003,9 @@ Content-Length: 113
 <div class="sect2">
 <h3 id="_캘린더_상세_조회"><a class="link" href="#_캘린더_상세_조회">8.1. 캘린더 상세 조회</a></h3>
 <div class="sect3">
-<h4 id="_success_8"><a class="link" href="#_success_8">8.1.1. <code>Success</code></a></h4>
+<h4 id="_success_9"><a class="link" href="#_success_9">8.1.1. <code>Success</code></a></h4>
 <div class="sect4">
-<h5 id="_success_8_http_request"><a class="link" href="#_success_8_http_request">HTTP request</a></h5>
+<h5 id="_success_9_http_request"><a class="link" href="#_success_9_http_request">HTTP request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/calendars/1 HTTP/1.1
@@ -2919,7 +3016,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect4">
-<h5 id="_success_8_http_response"><a class="link" href="#_success_8_http_response">HTTP response</a></h5>
+<h5 id="_success_9_http_response"><a class="link" href="#_success_9_http_response">HTTP response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2946,7 +3043,7 @@ Content-Length: 344
 </div>
 </div>
 <div class="sect4">
-<h5 id="_success_8_request_headers"><a class="link" href="#_success_8_request_headers">Request headers</a></h5>
+<h5 id="_success_9_request_headers"><a class="link" href="#_success_9_request_headers">Request headers</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -2967,7 +3064,7 @@ Content-Length: 344
 </table>
 </div>
 <div class="sect4">
-<h5 id="_success_8_response_fields"><a class="link" href="#_success_8_response_fields">Response fields</a></h5>
+<h5 id="_success_9_response_fields"><a class="link" href="#_success_9_response_fields">Response fields</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -3055,9 +3152,9 @@ Content-Length: 344
 <div class="sect2">
 <h3 id="_캘린더_년도_및_월별_상세_조회"><a class="link" href="#_캘린더_년도_및_월별_상세_조회">8.2. 캘린더 년도 및 월별 상세 조회</a></h3>
 <div class="sect3">
-<h4 id="_success_9"><a class="link" href="#_success_9">8.2.1. <code>Success</code></a></h4>
+<h4 id="_success_10"><a class="link" href="#_success_10">8.2.1. <code>Success</code></a></h4>
 <div class="sect4">
-<h5 id="_success_9_http_request"><a class="link" href="#_success_9_http_request">HTTP request</a></h5>
+<h5 id="_success_10_http_request"><a class="link" href="#_success_10_http_request">HTTP request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/calendars HTTP/1.1
@@ -3074,7 +3171,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect4">
-<h5 id="_success_9_http_response"><a class="link" href="#_success_9_http_response">HTTP response</a></h5>
+<h5 id="_success_10_http_response"><a class="link" href="#_success_10_http_response">HTTP response</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3148,7 +3245,7 @@ Content-Length: 1422
 </div>
 </div>
 <div class="sect4">
-<h5 id="_success_9_request_headers"><a class="link" href="#_success_9_request_headers">Request headers</a></h5>
+<h5 id="_success_10_request_headers"><a class="link" href="#_success_10_request_headers">Request headers</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -3169,7 +3266,7 @@ Content-Length: 1422
 </table>
 </div>
 <div class="sect4">
-<h5 id="_success_9_response_fields"><a class="link" href="#_success_9_response_fields">Response fields</a></h5>
+<h5 id="_success_10_response_fields"><a class="link" href="#_success_10_response_fields">Response fields</a></h5>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -3267,9 +3364,9 @@ Content-Length: 1422
 <div class="sect2">
 <h3 id="_캘린더_작성"><a class="link" href="#_캘린더_작성">8.3. 캘린더 작성</a></h3>
 <div class="sect3">
-<h4 id="_success_10"><a class="link" href="#_success_10">8.3.1. <code>Success</code></a></h4>
+<h4 id="_success_11"><a class="link" href="#_success_11">8.3.1. <code>Success</code></a></h4>
 <div class="sect4">
-<h5 id="_success_10_http_request"><a class="link" href="#_success_10_http_request">HTTP request</a></h5>
+<h5 id="_success_11_http_request"><a class="link" href="#_success_11_http_request">HTTP request</a></h5>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/calendars HTTP/1.1
@@ -3292,110 +3389,10 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect4">
-<h5 id="_success_10_http_response"><a class="link" href="#_success_10_http_response">HTTP response</a></h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Content-Type: application/json;charset=UTF-8
-Content-Length: 88
-
-{
-  "code" : "1000",
-  "message" : "요청에 성공하셨습니다.",
-  "data" : null
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect4">
-<h5 id="_success_10_request_headers"><a class="link" href="#_success_10_request_headers">Request headers</a></h5>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect4">
-<h5 id="_success_10_response_fields"><a class="link" href="#_success_10_response_fields">Response fields</a></h5>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_캘린더_수정"><a class="link" href="#_캘린더_수정">8.4. 캘린더 수정</a></h3>
-<div class="sect3">
-<h4 id="_success_11"><a class="link" href="#_success_11">8.4.1. <code>Success</code></a></h4>
-<div class="sect4">
-<h5 id="_success_11_http_request"><a class="link" href="#_success_11_http_request">HTTP request</a></h5>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/calendars/1 HTTP/1.1
-Content-Type: application/json;charset=UTF-8
-Authorization: Bearer access-token
-Content-Length: 201
-Host: localhost:8080
-
-{
-  "title" : "캘린더 제목",
-  "memo" : "중요함",
-  "color" : "PRIMARY",
-  "alarm" : "NONE",
-  "startDate" : "2023-12-24",
-  "endDate" : "2023-12-25",
-  "startTime" : null,
-  "endTime" : null
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect4">
 <h5 id="_success_11_http_response"><a class="link" href="#_success_11_http_response">HTTP response</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
 Content-Type: application/json;charset=UTF-8
 Content-Length: 88
 
@@ -3465,16 +3462,29 @@ Content-Length: 88
 </div>
 </div>
 <div class="sect2">
-<h3 id="_캘린더_삭제"><a class="link" href="#_캘린더_삭제">8.5. 캘린더 삭제</a></h3>
+<h3 id="_캘린더_수정"><a class="link" href="#_캘린더_수정">8.4. 캘린더 수정</a></h3>
 <div class="sect3">
-<h4 id="_success_12"><a class="link" href="#_success_12">8.5.1. <code>Success</code></a></h4>
+<h4 id="_success_12"><a class="link" href="#_success_12">8.4.1. <code>Success</code></a></h4>
 <div class="sect4">
 <h5 id="_success_12_http_request"><a class="link" href="#_success_12_http_request">HTTP request</a></h5>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/calendars/1 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/calendars/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access-token
-Host: localhost:8080</code></pre>
+Content-Length: 201
+Host: localhost:8080
+
+{
+  "title" : "캘린더 제목",
+  "memo" : "중요함",
+  "color" : "PRIMARY",
+  "alarm" : "NONE",
+  "startDate" : "2023-12-24",
+  "endDate" : "2023-12-25",
+  "startTime" : null,
+  "endTime" : null
+}</code></pre>
 </div>
 </div>
 </div>
@@ -3551,13 +3561,100 @@ Content-Length: 88
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_캘린더_삭제"><a class="link" href="#_캘린더_삭제">8.5. 캘린더 삭제</a></h3>
+<div class="sect3">
+<h4 id="_success_13"><a class="link" href="#_success_13">8.5.1. <code>Success</code></a></h4>
+<div class="sect4">
+<h5 id="_success_13_http_request"><a class="link" href="#_success_13_http_request">HTTP request</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/calendars/1 HTTP/1.1
+Authorization: Bearer access-token
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_success_13_http_response"><a class="link" href="#_success_13_http_response">HTTP response</a></h5>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 88
+
+{
+  "code" : "1000",
+  "message" : "요청에 성공하셨습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect4">
+<h5 id="_success_13_request_headers"><a class="link" href="#_success_13_request_headers">Request headers</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect4">
+<h5 id="_success_13_response_fields"><a class="link" href="#_success_13_response_fields">Response fields</a></h5>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_diary"><a class="link" href="#_diary">9. Diary</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_success_13"><a class="link" href="#_success_13">9.1. <code>Success</code></a></h3>
+<h3 id="_success_14"><a class="link" href="#_success_14">9.1. <code>Success</code></a></h3>
 
 </div>
 <div class="sect2">
@@ -3566,7 +3663,7 @@ Content-Length: 88
 <h4 id="_데이트_날짜_기준_다이어리_조회_http_request"><a class="link" href="#_데이트_날짜_기준_다이어리_조회_http_request">9.2.1. HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/diaries/memory-date?memoryDate=2024-02-02 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/diaries/memory-date?memoryDate=2024-02-13 HTTP/1.1
 Authorization: Bearer access-token
 Host: localhost:8080</code></pre>
 </div>
@@ -3630,7 +3727,7 @@ Content-Length: 1125
       "diaryId" : 1,
       "userId" : 1,
       "title" : "제목1",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : "장소1",
       "content" : "내용1",
       "imageUrl" : "imageURL1"
@@ -3638,7 +3735,7 @@ Content-Length: 1125
       "diaryId" : 2,
       "userId" : 1,
       "title" : "제목2",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : "장소2",
       "content" : "내용2",
       "imageUrl" : "imageURL2"
@@ -3646,7 +3743,7 @@ Content-Length: 1125
       "diaryId" : 3,
       "userId" : 1,
       "title" : "제목3",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : "장소3",
       "content" : "내용3",
       "imageUrl" : "imageURL3"
@@ -3654,7 +3751,7 @@ Content-Length: 1125
       "diaryId" : 4,
       "userId" : 1,
       "title" : "제목4",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : "장소4",
       "content" : "내용4",
       "imageUrl" : "imageURL4"
@@ -3662,7 +3759,7 @@ Content-Length: 1125
       "diaryId" : 5,
       "userId" : 1,
       "title" : "제목5",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : "장소5",
       "content" : "내용5",
       "imageUrl" : "imageURL5"
@@ -3759,7 +3856,7 @@ Content-Length: 1125
 <h4 id="_커서_기반_다이어리_리스트_조회_http_request"><a class="link" href="#_커서_기반_다이어리_리스트_조회_http_request">9.3.1. HTTP request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/diaries/cursor?memoryDate=2024-02-02&amp;searchType=BEFORE&amp;diaryId=-1&amp;pageSize=10 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/diaries/cursor?memoryDate=2024-02-13&amp;searchType=BEFORE&amp;diaryId=-1&amp;pageSize=10 HTTP/1.1
 Authorization: Bearer access-token
 Host: localhost:8080</code></pre>
 </div>
@@ -3835,7 +3932,7 @@ Content-Length: 2058
       "diaryId" : 1,
       "userId" : 1,
       "title" : "제목1",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : null,
       "content" : "내용1",
       "imageUrls" : [ ]
@@ -3843,7 +3940,7 @@ Content-Length: 2058
       "diaryId" : 2,
       "userId" : 2,
       "title" : "제목2",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : null,
       "content" : "내용2",
       "imageUrls" : [ ]
@@ -3851,7 +3948,7 @@ Content-Length: 2058
       "diaryId" : 3,
       "userId" : 3,
       "title" : "제목3",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : null,
       "content" : "내용3",
       "imageUrls" : [ ]
@@ -3859,7 +3956,7 @@ Content-Length: 2058
       "diaryId" : 4,
       "userId" : 4,
       "title" : "제목4",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : null,
       "content" : "내용4",
       "imageUrls" : [ ]
@@ -3867,7 +3964,7 @@ Content-Length: 2058
       "diaryId" : 5,
       "userId" : 5,
       "title" : "제목5",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : null,
       "content" : "내용5",
       "imageUrls" : [ ]
@@ -3875,7 +3972,7 @@ Content-Length: 2058
       "diaryId" : 6,
       "userId" : 6,
       "title" : "제목6",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : null,
       "content" : "내용6",
       "imageUrls" : [ ]
@@ -3883,7 +3980,7 @@ Content-Length: 2058
       "diaryId" : 7,
       "userId" : 7,
       "title" : "제목7",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : null,
       "content" : "내용7",
       "imageUrls" : [ ]
@@ -3891,7 +3988,7 @@ Content-Length: 2058
       "diaryId" : 8,
       "userId" : 8,
       "title" : "제목8",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : null,
       "content" : "내용8",
       "imageUrls" : [ ]
@@ -3899,7 +3996,7 @@ Content-Length: 2058
       "diaryId" : 9,
       "userId" : 9,
       "title" : "제목9",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : null,
       "content" : "내용9",
       "imageUrls" : [ ]
@@ -3907,14 +4004,14 @@ Content-Length: 2058
       "diaryId" : 10,
       "userId" : 10,
       "title" : "제목10",
-      "memoryDate" : "2024-02-02",
+      "memoryDate" : "2024-02-13",
       "place" : null,
       "content" : "내용10",
       "imageUrls" : [ ]
     } ],
     "totalCount" : 10,
     "diaryId" : 10,
-    "memoryDate" : "2024-02-02"
+    "memoryDate" : "2024-02-13"
   }
 }</code></pre>
 </div>
@@ -4036,7 +4133,7 @@ Content-Length: 268
     "diaryId" : 1,
     "userId" : 1,
     "title" : "다이어리 제목",
-    "memoryDate" : "2024-02-02",
+    "memoryDate" : "2024-02-13",
     "place" : "장소",
     "content" : "내용",
     "imageUrls" : [ ]
@@ -4129,7 +4226,7 @@ Host: localhost:8080
 
 {
   "title" : "다이어리 제목",
-  "memoryDate" : "2024-02-02",
+  "memoryDate" : "2024-02-13",
   "place" : "장소",
   "content" : "내용",
   "imageUrls" : [ "imageUrl1", "imageUrl2" ]
@@ -4143,7 +4240,7 @@ Host: localhost:8080
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
   "title" : "다이어리 제목",
-  "memoryDate" : "2024-02-02",
+  "memoryDate" : "2024-02-13",
   "place" : "장소",
   "content" : "내용",
   "imageUrls" : [ "imageUrl1", "imageUrl2" ]
@@ -4280,7 +4377,7 @@ Host: localhost:8080
 
 {
   "title" : "다이어리 제목 수정",
-  "memoryDate" : "2024-02-02",
+  "memoryDate" : "2024-02-13",
   "place" : "장소",
   "content" : "내용 수정",
   "imageUrls" : [ "imageUrl1", "imageUrl2" ]
@@ -4294,7 +4391,7 @@ Host: localhost:8080
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
   "title" : "다이어리 제목 수정",
-  "memoryDate" : "2024-02-02",
+  "memoryDate" : "2024-02-13",
   "place" : "장소",
   "content" : "내용 수정",
   "imageUrls" : [ "imageUrl1", "imageUrl2" ]
@@ -4362,6 +4459,114 @@ Content-Length: 88
 </div>
 </div>
 </div>
+<div class="sect3">
+<h4 id="_다이어리_수정_response_fields"><a class="link" href="#_다이어리_수정_response_fields">9.6.5. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_다이어리_삭제"><a class="link" href="#_다이어리_삭제">9.7. 다이어리 삭제</a></h3>
+<div class="sect3">
+<h4 id="_다이어리_삭제_http_request"><a class="link" href="#_다이어리_삭제_http_request">9.7.1. HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/diaries/1 HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_다이어리_삭제_http_response"><a class="link" href="#_다이어리_삭제_http_response">9.7.2. HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 88
+
+{
+  "code" : "1000",
+  "message" : "요청에 성공하셨습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_다이어리_삭제_response_body"><a class="link" href="#_다이어리_삭제_response_body">9.7.3. Response body</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "code" : "1000",
+  "message" : "요청에 성공하셨습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_다이어리_삭제_response_fields"><a class="link" href="#_다이어리_삭제_response_fields">9.7.4. Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+</tbody>
+</table>
+</div>
 </div>
 </div>
 </div>
@@ -4369,7 +4574,7 @@ Content-Length: 88
 <div id="footer">
 <div id="footer-text">
 Version 1.0.2-SNAPSHOT<br>
-Last updated 2024-02-02 17:59:44 +0900
+Last updated 2024-02-06 12:23:01 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/lovebird-api/src/test/kotlin/com/lovebird/api/controller/user/AuthControllerTest.kt
+++ b/lovebird-api/src/test/kotlin/com/lovebird/api/controller/user/AuthControllerTest.kt
@@ -6,11 +6,14 @@ import com.lovebird.api.dto.request.user.SignUpRequest
 import com.lovebird.api.dto.response.user.SignInResponse
 import com.lovebird.api.dto.response.user.SignUpResponse
 import com.lovebird.api.service.user.AuthService
+import com.lovebird.api.utils.AuthTestFixture.getAccessTokenResponse
 import com.lovebird.api.utils.andExpectData
 import com.lovebird.api.utils.restdocs.BOOLEAN
 import com.lovebird.api.utils.restdocs.STRING
 import com.lovebird.api.utils.restdocs.andDocument
+import com.lovebird.api.utils.restdocs.headerMeans
 import com.lovebird.api.utils.restdocs.requestBody
+import com.lovebird.api.utils.restdocs.requestHeaders
 import com.lovebird.api.utils.restdocs.restDocMockMvcBuild
 import com.lovebird.api.utils.restdocs.type
 import com.lovebird.api.utils.shouldBe
@@ -351,6 +354,37 @@ class AuthControllerTest(
 							"state" type STRING means "상태"
 						),
 						envelopeResponseBody()
+					)
+			}
+		}
+	}
+
+	describe("POST : /api/v1/auth/recreate-access-token") {
+		val url = "$baseUrl/access-token"
+		val refreshToken = "refresh-token"
+
+		context("정상적인 Refresh Token 일 때") {
+			val request = request(HttpMethod.POST, url)
+				.header("Refresh", refreshToken)
+
+			it("1000 SUCCESS") {
+				every { authService.recreateAccessToken(refreshToken) } returns getAccessTokenResponse()
+
+				mockMvc.perform(request)
+					.andExpect(status().isOk)
+					.andExpectData(
+						jsonPath("$.code") shouldBe ReturnCode.SUCCESS.code,
+						jsonPath("$.message") shouldBe ReturnCode.SUCCESS.message,
+						jsonPath("$.data.accessToken") shouldBe "access-token"
+					)
+					.andDocument(
+						"1000-recreate-access-token",
+						requestHeaders(
+							"Refresh" headerMeans "리프레시 토큰"
+						),
+						envelopeResponseBody(
+							"data.accessToken" type STRING means "액세스 토큰"
+						)
 					)
 			}
 		}

--- a/lovebird-api/src/test/kotlin/com/lovebird/api/utils/AuthTestFixture.kt
+++ b/lovebird-api/src/test/kotlin/com/lovebird/api/utils/AuthTestFixture.kt
@@ -1,0 +1,10 @@
+package com.lovebird.api.utils
+
+import com.lovebird.api.dto.response.user.AccessTokenResponse
+
+object AuthTestFixture {
+
+	fun getAccessTokenResponse(): AccessTokenResponse {
+		return AccessTokenResponse("access-token")
+	}
+}

--- a/lovebird-api/src/test/kotlin/com/lovebird/api/utils/CommonTestFixture.kt
+++ b/lovebird-api/src/test/kotlin/com/lovebird/api/utils/CommonTestFixture.kt
@@ -1,5 +1,6 @@
 package com.lovebird.api.utils
 
+import com.lovebird.api.vo.PrincipalUser
 import com.lovebird.common.enums.Provider
 import com.lovebird.domain.entity.User
 import org.springframework.test.util.ReflectionTestUtils
@@ -14,5 +15,10 @@ object CommonTestFixture {
 		)
 		ReflectionTestUtils.setField(user, "id", id)
 		return user
+	}
+
+	fun getPrincipalUser(id: Long, providerId: String): PrincipalUser {
+		val user = getUser(id, providerId)
+		return PrincipalUser.of(user)
 	}
 }


### PR DESCRIPTION
> ### Issue Number

#73

> ### Description

- Refresh Token으로 Access Token을 재발급 받는 로직을 작성한다.

> ### Core Code

JwtValidator의 getPrincipalUser로 토큰 검증 및 PrincipalUser를 가져오고, JwtProvider를 통해 액세스 토큰을 발급합니다.

```kotlin
@Component
class JwtValidator(
	private val key: Key,
	private val userReader: UserReader
) {
        . . .
        fun getPrincipalUser(token: String): PrincipalUser {
		val claims = getTokenClaims(token)
		val user: User = userReader.findEntityById(claims.get("id", String::class.java).toLong())

		return PrincipalUser.of(user)
	}
        . . .
}
```

> ### etc
