### PR TITLE
Hotfix | #81 | @YongsHub | v1.0.1 출시 위해 Projection 방식 변경

### DIFF
--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/CalendarListResponseParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/CalendarListResponseParam.kt
@@ -2,10 +2,11 @@ package com.lovebird.domain.dto.query
 
 import com.lovebird.common.enums.Alarm
 import com.lovebird.common.enums.Color
+import com.querydsl.core.annotations.QueryProjection
 import java.time.LocalDate
 import java.time.LocalTime
 
-data class CalendarListResponseParam(
+data class CalendarListResponseParam @QueryProjection constructor(
 	val id: Long,
 	val userId: Long,
 	val title: String,

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/DiarySimpleResponseParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/DiarySimpleResponseParam.kt
@@ -1,8 +1,9 @@
 package com.lovebird.domain.dto.query
 
+import com.querydsl.core.annotations.QueryProjection
 import java.time.LocalDate
 
-data class DiarySimpleResponseParam(
+data class DiarySimpleResponseParam @QueryProjection constructor(
 	val diaryId: Long,
 	val userId: Long,
 	var title: String,

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/ProfilePartnerResponseParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/ProfilePartnerResponseParam.kt
@@ -1,10 +1,13 @@
 package com.lovebird.domain.dto.query
 
+import com.querydsl.core.annotations.QueryProjection
 import java.time.LocalDate
 
-data class ProfilePartnerResponseParam(
+data class ProfilePartnerResponseParam @QueryProjection constructor(
 	val partnerId: Long,
+	val partnerEmail: String,
 	val partnerNickname: String?,
+	val firstDate: LocalDate,
 	val partnerBirthday: LocalDate?,
 	val partnerImageUrl: String?
 )

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/ProfileUserResponseParam.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/dto/query/ProfileUserResponseParam.kt
@@ -1,8 +1,9 @@
 package com.lovebird.domain.dto.query
 
+import com.querydsl.core.annotations.QueryProjection
 import java.time.LocalDate
 
-data class ProfileUserResponseParam(
+data class ProfileUserResponseParam @QueryProjection constructor(
 	val userId: Long,
 	val coupleEntryId: Long?,
 	val email: String,

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/CalendarQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/CalendarQueryRepository.kt
@@ -2,8 +2,8 @@ package com.lovebird.domain.repository.query
 
 import com.lovebird.domain.dto.query.CalendarListResponseParam
 import com.lovebird.domain.dto.query.CalenderListRequestParam
+import com.lovebird.domain.dto.query.QCalendarListResponseParam
 import com.lovebird.domain.entity.QCalendar.calendar
-import com.querydsl.core.types.Projections
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
@@ -16,8 +16,7 @@ class CalendarQueryRepository(
 	fun findCalendarsByDateAndUserIdAndPartnerId(param: CalenderListRequestParam): List<CalendarListResponseParam> {
 		return queryFactory
 			.select(
-				Projections.constructor(
-					CalendarListResponseParam::class.java,
+				QCalendarListResponseParam(
 					calendar.id,
 					calendar.user.id,
 					calendar.title,

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/DiaryQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/DiaryQueryRepository.kt
@@ -4,6 +4,7 @@ import com.lovebird.domain.dto.query.DiaryListRequestParam
 import com.lovebird.domain.dto.query.DiaryResponseParam
 import com.lovebird.domain.dto.query.DiarySimpleRequestParam
 import com.lovebird.domain.dto.query.DiarySimpleResponseParam
+import com.lovebird.domain.dto.query.QDiarySimpleResponseParam
 import com.lovebird.domain.entity.QDiary
 import com.lovebird.domain.entity.QDiary.diary
 import com.lovebird.domain.entity.QDiaryImage.diaryImage
@@ -94,15 +95,14 @@ class DiaryQueryRepository(
 	fun findAllByMemoryDate(param: DiarySimpleRequestParam): List<DiarySimpleResponseParam> {
 		return queryFactory
 			.select(
-				Projections.constructor(
-					DiarySimpleResponseParam::class.java,
+				QDiarySimpleResponseParam(
 					diary.id,
 					diary.user.id,
 					diary.title,
 					diary.memoryDate,
 					diary.place,
 					diary.content,
-					diary.diaryImages.get(0)
+					diary.diaryImages.get(0).imageUrl
 				)
 			)
 			.from(diary)
@@ -116,15 +116,14 @@ class DiaryQueryRepository(
 	fun findAll(userId: Long, partnerId: Long?): List<DiarySimpleResponseParam> {
 		return queryFactory
 			.select(
-				Projections.constructor(
-					DiarySimpleResponseParam::class.java,
+				QDiarySimpleResponseParam(
 					diary.id,
 					diary.user.id,
 					diary.title,
 					diary.memoryDate,
 					diary.place,
 					diary.content,
-					diary.diaryImages.get(0)
+					diary.diaryImages.get(0).imageUrl
 				)
 			)
 			.from(diary)

--- a/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/ProfileQueryRepository.kt
+++ b/lovebird-domain/src/main/kotlin/com/lovebird/domain/repository/query/ProfileQueryRepository.kt
@@ -2,9 +2,10 @@ package com.lovebird.domain.repository.query
 
 import com.lovebird.domain.dto.query.ProfilePartnerResponseParam
 import com.lovebird.domain.dto.query.ProfileUserResponseParam
+import com.lovebird.domain.dto.query.QProfilePartnerResponseParam
+import com.lovebird.domain.dto.query.QProfileUserResponseParam
 import com.lovebird.domain.entity.QCoupleEntry.coupleEntry
 import com.lovebird.domain.entity.QProfile.profile
-import com.querydsl.core.types.Projections
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
@@ -17,8 +18,7 @@ class ProfileQueryRepository(
 	fun findDetailUserParamByUser(userId: Long): ProfileUserResponseParam? {
 		return queryFactory
 			.select(
-				Projections.constructor(
-					ProfileUserResponseParam::class.java,
+				QProfileUserResponseParam(
 					profile.user.id,
 					coupleEntry.id,
 					profile.email,
@@ -38,8 +38,7 @@ class ProfileQueryRepository(
 	fun findDetailPartnerParamByUser(partnerId: Long): ProfilePartnerResponseParam? {
 		return queryFactory
 			.select(
-				Projections.constructor(
-					ProfilePartnerResponseParam::class.java,
+				QProfilePartnerResponseParam(
 					profile.user.id,
 					profile.email,
 					profile.nickname,


### PR DESCRIPTION
> ### Issue Number

#81 

> ### Description

- Projection.constructor를 활용하면 컴파일 단계에서 생성자 에러를 잡지 못하는 케이스가 존재하기 때문에 parameter 순서와 타입, 개수 등을 지키기 위해 생성 방식을 변경합니다

> ### Core Code

```kotlin
예시 케이스
data class ProfileUserResponseParam @QueryProjection constructor(
	val userId: Long,
	val coupleEntryId: Long?,
	val email: String,
	val nickname: String,
	val firstDate: LocalDate?,
	val birthday: LocalDate?,
	val profileImageUrl: String
)
```

> ### etc
