### PR TITLE
Feature | #79 | @lcomment | slack webhook 구성 및 ExceptionHandler에 추가

### DIFF
--- a/.github/workflows/cd-develop.yml
+++ b/.github/workflows/cd-develop.yml
@@ -70,6 +70,7 @@ jobs:
           jwt.access-header: ${{ secrets.ACCESS_HEADER }}
           jwt.refresh-header: ${{ secrets.REFRESH_HEADER }}
           jwt.secret: ${{ secrets.DEV_JWT_SECRET }}
+          slack.webhook.url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Set client-dev yml file
         uses: microsoft/variable-substitution@v1

--- a/lovebird-api/build.gradle.kts
+++ b/lovebird-api/build.gradle.kts
@@ -33,6 +33,9 @@ dependencies {
 	implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
 	implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
+	// Slack
+	implementation("net.gpedro.integrations.slack:slack-webhook:1.4.0")
+
 	// Test
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/config/SlackWebhookConfig.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/config/SlackWebhookConfig.kt
@@ -1,0 +1,18 @@
+package com.lovebird.api.config
+
+import net.gpedro.integrations.slack.SlackApi
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SlackWebhookConfig(
+	@Value("\${slack.webhook.url}")
+	private val slackWebhookUrl: String
+) {
+
+	@Bean
+	fun slackApi(): SlackApi {
+		return SlackApi(slackWebhookUrl)
+	}
+}

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/slack/SlackService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/slack/SlackService.kt
@@ -1,0 +1,61 @@
+package com.lovebird.api.service.slack
+
+import jakarta.servlet.http.HttpServletRequest
+import net.gpedro.integrations.slack.SlackApi
+import net.gpedro.integrations.slack.SlackAttachment
+import net.gpedro.integrations.slack.SlackField
+import net.gpedro.integrations.slack.SlackMessage
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class SlackService(
+	private val slackApi: SlackApi,
+	private val environment: Environment,
+	@Value("\${slack.webhook.is-enable}")
+	private val isEnable: Boolean
+) {
+
+	fun sendSlackForError(exception: Exception, request: HttpServletRequest) {
+		if (!isEnable) {
+			return
+		}
+		val slackAttachment = SlackAttachment()
+		slackAttachment.setFallback("Error")
+		slackAttachment.setColor("danger")
+		slackAttachment.setTitle("Error Detect")
+		slackAttachment.setTitleLink(request.contextPath)
+		slackAttachment.setText(exception.stackTraceToString())
+		slackAttachment.setFields(
+			listOf(
+				SlackField().setTitle("Request URL").setValue(request.requestURL.toString()),
+				SlackField().setTitle("Request Method").setValue(request.method),
+				SlackField().setTitle("Request Parameter").setValue(getRequestParameters(request)),
+				SlackField().setTitle("Request Time").setValue(LocalDateTime.now().toString()),
+				SlackField().setTitle("Request IP").setValue(request.remoteAddr),
+				SlackField().setTitle("Request User-Agent").setValue(request.getHeader("User-Agent"))
+			)
+		)
+		val profile = environment.getProperty("spring.profiles.active")
+		val slackMessage = SlackMessage()
+
+		slackMessage.setAttachments(listOf(slackAttachment))
+		slackMessage.setChannel("#error-log")
+		slackMessage.setUsername("$profile API Error")
+		slackMessage.setIcon(":alert:")
+		slackMessage.setText("$profile api 에러 발생")
+
+		slackApi.call(slackMessage)
+	}
+
+	private fun getRequestParameters(request: HttpServletRequest): String {
+		val parameterMap = request.parameterMap
+		val sb = StringBuilder()
+		parameterMap.forEach { (key, value) ->
+			sb.append("$key: ${value.joinToString(", ")}\n")
+		}
+		return sb.toString()
+	}
+}

--- a/lovebird-api/src/main/kotlin/com/lovebird/api/service/slack/SlackService.kt
+++ b/lovebird-api/src/main/kotlin/com/lovebird/api/service/slack/SlackService.kt
@@ -38,7 +38,7 @@ class SlackService(
 				SlackField().setTitle("Request User-Agent").setValue(request.getHeader("User-Agent"))
 			)
 		)
-		val profile = environment.getProperty("spring.profiles.active")
+		val profile = environment.getProperty("spring.profiles.default")
 		val slackMessage = SlackMessage()
 
 		slackMessage.setAttachments(listOf(slackAttachment))

--- a/lovebird-api/src/main/resources/application-dev.yml
+++ b/lovebird-api/src/main/resources/application-dev.yml
@@ -12,3 +12,7 @@ jwt:
         refresh-token: 2592000000
     grant-type: Bearer
 
+slack:
+    webhook:
+        is-enable: true
+        url: ${SLACK_WEBHOOK_URL}

--- a/lovebird-api/src/main/resources/application-local.yml
+++ b/lovebird-api/src/main/resources/application-local.yml
@@ -12,3 +12,7 @@ jwt:
         refresh-token: 2592000000
     grant-type: Bearer
 
+slack:
+    webhook:
+        is-enable: false
+        url: url

--- a/lovebird-api/src/main/resources/application-prod.yml
+++ b/lovebird-api/src/main/resources/application-prod.yml
@@ -11,3 +11,8 @@ jwt:
         access-token: ${JWT_ACCESS_TOKEN_EXPIRATION}
         refresh-token: ${JWT_REFRESH_TOKEN_EXPIRATION}
     grant-type: Bearer
+
+slack:
+    webhook:
+        is-enable: true
+        url: ${SLACK_WEBHOOK_URL}

--- a/lovebird-api/src/main/resources/application.yml
+++ b/lovebird-api/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
         default: ${APPLICATION_PROFILE}
     application:
         title: Lovebird
-        version: 1.0.2
+        version: 1.1.0
     banner:
         location: classpath:/app-banner.dat
     config:

--- a/lovebird-api/src/test/kotlin/com/lovebird/api/common/base/ControllerDescribeSpec.kt
+++ b/lovebird-api/src/test/kotlin/com/lovebird/api/common/base/ControllerDescribeSpec.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.lovebird.api.config.WebMvcConfig
+import com.lovebird.api.service.slack.SlackService
 import com.lovebird.api.utils.restdocs.OBJECT
 import com.lovebird.api.utils.restdocs.RestDocsField
 import com.lovebird.api.utils.restdocs.STRING
@@ -26,6 +27,9 @@ abstract class ControllerDescribeSpec(
 
 	@MockkBean
 	protected lateinit var jwtValidator: JwtValidator
+
+	@MockkBean
+	protected lateinit var slackService: SlackService
 
 	companion object {
 		private val mapper: ObjectMapper = ObjectMapper()


### PR DESCRIPTION
> ### Issue Number

#79

> ### Description

500 에러 발생 시 팀 Slack의  `error-log` 채널에 관련 내용이 메시지로 전송되도록 구성했습니다.

> ### Core Code

**SlackService.kt**

```kotlin
	private fun getRequestParameters(request: HttpServletRequest): String {
		val parameterMap = request.parameterMap
		val sb = StringBuilder()
		parameterMap.forEach { (key, value) ->
			sb.append("$key: ${value.joinToString(", ")}\n")
		}
		return sb.toString()
	}
```

> ### etc
